### PR TITLE
Adding support for stacked bar charts to display as a percentage of the total

### DIFF
--- a/src/pvc/pvcBar.js
+++ b/src/pvc/pvcBar.js
@@ -9,7 +9,7 @@ pvc.BarChart = pvc.CategoricalAbstract.extend({
     constructor: function(o){
 
         this.base(o);
-
+        var myself = this;
         var _defaults = {
             showValues: true,
             stacked: false,
@@ -22,7 +22,15 @@ pvc.BarChart = pvc.CategoricalAbstract.extend({
             showTooltips: true,
             orientation: "vertical",
             orthoFixedMin: null,
-            orthoFixedMax: null
+            orthoFixedMax: null,
+            tooltipFormat: function(s,c,v){
+                var ret = s+", "+c+":  " + myself.options.valueFormat(v);
+                if (myself.options.stacked && myself.options.percentage) {
+                    ret = ret + "%";
+                }
+                return ret;
+            }
+
         };
 
 

--- a/src/pvc/pvcCategoricalAbstract.js
+++ b/src/pvc/pvcCategoricalAbstract.js
@@ -384,7 +384,7 @@ pvc.CategoricalAbstract = pvc.TimeseriesAbstract.extend({
         var max, min;
 
         if(this.options.stacked){
-            max = this.dataEngine.getCategoriesMaxSumOfVisibleSeries();
+            max = this.options.percentage ? 100 : this.dataEngine.getCategoriesMaxSumOfVisibleSeries();
             min = 0;
         }
         else{

--- a/src/pvc/pvcData.js
+++ b/src/pvc/pvcData.js
@@ -423,6 +423,39 @@ pvc.DataEngine = Base.extend({
     },
 
     /*
+     * Returns the transposed values converted to percentages
+     */
+    getVisibleTransposedPercentages: function() {
+        var data = pvc.padMatrixWithZeros(this.getVisibleTransposedValues());
+        // this is data[series][category] - so first sum up the category data for each series, and get it's total
+        // then return the percentages
+        var categoryTotals = [];
+        for (var i = 0; i < data.length; i++) {
+            var series = data[i];
+            for (var j = 0; j < series.length; j++) {
+                var curTotal = categoryTotals[j];
+                if (typeof curTotal == "undefined" || curTotal == null) {
+                    curTotal = series[j];
+                }
+                else {
+                    curTotal = curTotal + series[j]
+                }
+                categoryTotals[j] = curTotal;
+
+            }
+        }
+
+        data = data.map(function(v) {
+            var cur = 0;
+            return v.map(function(a) {
+                var tot = categoryTotals[cur++];
+                return (tot == undefined || tot == null) ? 0 : (a * 100) / tot;
+            })
+        })
+        return data;
+    },
+
+    /*
      * Returns the values for a given series idx
      *
      */

--- a/src/pvc/pvcWaterfall.js
+++ b/src/pvc/pvcWaterfall.js
@@ -237,13 +237,17 @@ pvc.WaterfallChartPanel = pvc.BasePanel.extend({
         
         //clear needed to force re-fetch of visible series
         this.chart.dataEngine.clearDataCache();
-        
+
         var dataset = null
-        // check whether it does not kill the source-data    
-        dataset = this.stacked ?  
-        pvc.padMatrixWithZeros(this.chart.dataEngine
-            .getVisibleTransposedValues()) :
-        this.chart.dataEngine.getVisibleCategoriesIndexes();
+        // check whether it does not kill the source-data
+        if (this.stacked) {
+            // could by myself.chart.options.percentage, can't remember
+            dataset = this.chart.options.percentage ? this.chart.dataEngine.getVisibleTransposedPercentages() :
+                    pvc.padMatrixWithZeros(this.chart.dataEngine.getVisibleTransposedValues())
+        }
+        else {
+            dataset = this.chart.dataEngine.getVisibleCategoriesIndexes();
+        }
 
         if (this.waterfall)
             this.ruleData = this.constructWaterfall(dataset)


### PR DESCRIPTION
This is a patch that allows stacks in a stacked bar chart to display as a percentage of the total, rather than absolute values.
