### PR TITLE
Added support for secondAxis maximum value 

### DIFF
--- a/src/pvc/pvcCategoricalAbstract.js
+++ b/src/pvc/pvcCategoricalAbstract.js
@@ -607,7 +607,7 @@ pvc.CategoricalAbstract = pvc.TimeseriesAbstract.extend({
         
         // DOMAIN
         var bypassAxisSize   = pvc.get(keyArgs, 'bypassAxisSize',   false),
-            dMax = secondAxisOrthoFixedMax || this.dataEngine.getSecondAxisMax(),
+            dMax = options.secondAxisOrthoFixedMax || this.dataEngine.getSecondAxisMax(),
             dMin = this.dataEngine.getSecondAxisMin();
 
         if(dMin * dMax > 0 && options.secondAxisOriginIsZero){


### PR DESCRIPTION
Sometimes the line in a barchart is not shown properly due to the different scale of yAxis and secondAxis.
I added an option to let the user set a maximum value for secondAxis and use it instead of the value returned by dataEngine.getSecondAxisMax(). 
