### PR TITLE
Generic extension of marks with extension ids becomes possible through a...

### DIFF
--- a/package-res/pvc/pvc.js
+++ b/package-res/pvc/pvc.js
@@ -1248,6 +1248,12 @@ pv_Mark.prototype.wrap = function(f, m) {
     return f;
 };
 
+// Like https://github.com/mbostock/d3/wiki/Selections#call
+// for allowing general extension through extension points.
+pv.Mark.prototype.call = function(f) {
+    f.call(this, this);
+};
+
 pv_Mark.prototype.lock = function(prop, value){
     if(value !== undefined) {
         this[prop](value);

--- a/package-res/pvc/pvcBaseChart.extension.js
+++ b/package-res/pvc/pvcBaseChart.extension.js
@@ -72,8 +72,9 @@ pvc.BaseChart
                         } else if(isRealMarkAndWrapOrConstOnly && type === 'function') {
                             if(constOnly) { return; }
                             
-                            // TODO: "add" extension idiom - any other exclusions?
-                            if(m !== 'add') { v = wrap.call(mark, v, m); }
+                            // Don't wrap the "add" and "call" methods to support extension idioms.
+                            // "call" eliminates most use cases of renderCallback.
+                            if(m !== 'add' && m !== 'call') { v = wrap.call(mark, v, m); }
                         }
                     }
                     return v;
@@ -108,7 +109,7 @@ pvc.BaseChart
                                     mark.intercept(m, v, keyArgs2);
                                 } else {
                                     // Not really a mark or not a real protovis property.
-                                    // In this case, multiple calls and then ultiple arguments are allowed in v.
+                                    // In this case, multiple calls and then multiple arguments are allowed in v.
                                     if(v instanceof Array) {
                                         v.forEach(function(vi) { callMethod(mm, vi); });
                                     } else {


### PR DESCRIPTION
... d3'like "call" extension point method.

The function receives the corresponding mark as first argument (and `this` is also the mark).
One scenario that is particulary usefull and that is currently not possible through the "add" extension point is to anchor new marks to the extension id mark.

Example use:

``` javascript
extensionPoints: {
    bar_call: function() {
        return this.anchor('right').add(pv.Label)
            .text("Hello");
    }
}
```

@pamval please review.
