### PR TITLE
[ANALYZER-2336] - Update rules for applying custom series colors in CCC

### DIFF
--- a/package-res/pvc/pvcSunburstPanel.js
+++ b/package-res/pvc/pvcSunburstPanel.js
@@ -245,10 +245,13 @@ def
 
             var parent = scene.parent;
             if(parent) {
+                // Returning a nully color means to derive the color from the parent.
+                // Hopefully, there's a parent that is not the root.
+                // First-level nodes should have an own color.
                 baseColor = colorScale(scene);
-                if(!parent.isRoot() && !baseColor.isFixedColor) {
+                if(baseColor && !parent.isRoot()) {
                     baseColor = parent.color;
-                    if(index && colorBrightnessFactor)
+                    if(baseColor && index && colorBrightnessFactor)
                         baseColor = baseColor.brighter(
                             colorBrightnessFactor * index / (siblingsSize - 1));
                 }


### PR DESCRIPTION
- Cleaning up the way that the sunburst recognizing fixed colors.
  Instead of returning a property `isFixedColor` in the color objects (that because of that cannot be protovis cached instances), a _nully_ value is returned whenever the color is not fixed.
  In practice, not fixed colors would always be discarded, and a new color derived from the color of the parent.
- This commit should be accepted at approximately the same time as the corresponding "common-ui" commit, to avoid inconsistent builds (https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/229).
