### PR TITLE
[CLEANUP] Added missing sugar methods, on the Context and Scene classes,...

### DIFF
--- a/package-res/pvc/visual/Context.js
+++ b/package-res/pvc/visual/Context.js
@@ -76,6 +76,8 @@ def.type('pvc.visual.Context')
     getTick:     function(prop) { return this.scene.get('tick');     }, // Axis panels
     getX:        function(prop) { return this.scene.get('x');        },
     getY:        function(prop) { return this.scene.get('y');        },
+    getColor:    function(prop) { return this.scene.get('color');    },
+    getSize:     function(prop) { return this.scene.get('size');     },
 
     getSeriesLabel:   function(prop) { return this.scene.get('series',   'label'); },
     getCategoryLabel: function(prop) { return this.scene.get('category', 'label'); },
@@ -83,6 +85,8 @@ def.type('pvc.visual.Context')
     getTickLabel:     function(prop) { return this.scene.get('tick',     'label'); }, // Axis panels
     getXLabel:        function(prop) { return this.scene.get('x',        'label'); },
     getYLabel:        function(prop) { return this.scene.get('y',        'label'); },
+    getColorLabel:    function(prop) { return this.scene.get('color',    'label'); },
+    getSizeLabel:     function(prop) { return this.scene.get('size',     'label'); },
 
     // ---------------
 

--- a/package-res/pvc/visual/Scene.js
+++ b/package-res/pvc/visual/Scene.js
@@ -159,6 +159,8 @@ def.type('pvc.visual.Scene')
     getTick:     function(prop) { return this.get('tick');     }, // Axis panels
     getX:        function(prop) { return this.get('x');        },
     getY:        function(prop) { return this.get('y');        },
+    getColor:    function(prop) { return this.get('color');    },
+    getSize:     function(prop) { return this.get('size');     },
 
     getSeriesLabel:   function(prop) { return this.get('series',   'label'); },
     getCategoryLabel: function(prop) { return this.get('category', 'label'); },
@@ -166,6 +168,8 @@ def.type('pvc.visual.Scene')
     getTickLabel:     function(prop) { return this.get('tick',     'label'); }, // Axis panels
     getXLabel:        function(prop) { return this.get('x',        'label'); },
     getYLabel:        function(prop) { return this.get('y',        'label'); },
+    getColorLabel:    function(prop) { return this.get('color',    'label'); },
+    getSizeLabel:     function(prop) { return this.get('size',     'label'); },
 
     /**
      * Obtains the (first) group of this scene, or if inexistent


### PR DESCRIPTION
... to access the 'color' and 'size' variables: #getColor, #getSize, #getColorLabel, #getSizeLabel

@pamval please review.
These are 0.001% risk changes, and would be great if they would be included in the forthcoming CTools release.
