### PR TITLE
[ANALYZER-2391] - Data format is only applied to outer ring values in Sunburst chart

### DIFF
--- a/test/pvc.numberFormat-spec.js
+++ b/test/pvc.numberFormat-spec.js
@@ -35,6 +35,8 @@ define([
             });
         });
 
+        // TODO: a , not between # or 0, or to the left of a `.`, is ignored.
+        // ex: XxX,  ->   XxX
         describe("integer masks:", function() {
             describeSpecialValues("#");
 
@@ -118,7 +120,7 @@ define([
                 itMask(":0", 1000, ":1000");
             });
         });
-    
+
         describe("fractional masks:", function() {
             describeSpecialValues(".#");
 
@@ -126,12 +128,28 @@ define([
                 itMask(".#", 0,    "");
                 itMask(".#", 0.4,  ".4");
                 itMask(".#", 0.5,  ".5");
-                itMask(".#", 1,    "1");
+
+                describe("decimal point is only output if there's at least one actual significant digit in the value", function() {
+                    itMask(".#", 1,    "1");
+                    itMask(".#", 10,   "10");
+                    itMask(".#", 1000, "1000");
+                });
+
                 itMask(".#", 1.2,  "1.2");
                 itMask(".#", 1.24, "1.2");
                 itMask(".#", 1.25, "1.3");
-                itMask(".#", 10,   "10");
-                itMask(".#", 1000, "1000");
+
+                describe("decimal point is ignored when in the fractional part", function() {
+                    itMask("..#.", 1,    "1");
+                    itMask("..#.", 10,   "10");
+                    itMask("..#.", 1000, "1000");
+                });
+
+                describe("comma is ignored when in the fractional part", function() {
+                    itMask(".,#,", 1,    "1");
+                    itMask(".,#,", 10,   "10");
+                    itMask(".,#,", 1000, "1000");
+                });
             });
 
             describe("«.#0#» is the same as «.00#»", function() {
@@ -154,20 +172,209 @@ define([
                 itMask(".00#", 1.2545, "1.255");
             });
         });
+    
+        describe("integer and fractional masks:", function() {
+            describe("«0.##»", function() {
+                 itMask("0.##", 0,     "0");
+                 itMask("0.##", 0.2,   "0.2");
+                 itMask("0.##", 1.2,   "1.2");
+                 itMask("0.##", 1.23,  "1.23");
+                 itMask("0.##", 1.235, "1.24");
+                 itMask("0.##", 10,    "10");
+
+                 itMask("0.##", -0.2,   "-0.2");
+                 itMask("0.##", -1.2,   "-1.2");
+                 itMask("0.##", -1.23,  "-1.23");
+                 itMask("0.##", -1.235, "-1.24");
+                 itMask("0.##", -10,    "-10");
+            });
+        });
 
         describe("composite masks:", function() {
-            describe("«#;(#)»", function() {
-                itMask("#;(#)", 0,    "");
-                itMask("#;(#)", 0.4,  "");
-                itMask("#;(#)", 0.5,  "1");
-                itMask("#;(#)", 1,    "1");
-                itMask("#;(#)", 10,   "10");
-
-                itMask("#;(#)", -0.4,  "");
-                itMask("#;(#)", -0.5,  "(1)");
-                itMask("#;(#)", -1,    "(1)");
-                itMask("#;(#)", -10,   "(10)");
+            describe("A mask with positive and negative sections: «#;(#)»", function() {
+                describe("A zero value uses the positive mask", function() {
+                    itMask("#;(#)", 0,    "");    
+                });
+                describe("A positive value that rounds to zero uses the positive mask", function() {
+                    itMask("#;(#)", 0.4,  "");
+                });
+                describe("A negative value that rounds to zero uses the positive mask", function() {
+                    itMask("#;(#)", -0.4,  "");
+                });
+                
+                describe("Other positive values", function() {
+                    itMask("#;(#)", 0.5,  "1");
+                    itMask("#;(#)", 1,    "1");
+                    itMask("#;(#)", 10,   "10");
+                });
+                
+                describe("Other negative values", function() {
+                    itMask("#;(#)", -0.5,  "(1)");
+                    itMask("#;(#)", -1,    "(1)");
+                    itMask("#;(#)", -10,   "(10)");
+                });
             });
+            
+            describe("An empty positive section «;» is not like «»; it outputs nothing ", function() {
+                itMask(";", 0,  "");
+                itMask(";", 1,  "");
+                
+                itMask(";", -1,  "");
+                itMask(";", -10, "");
+            });
+
+            describe("An empty negative section uses the positive section: «#;»", function() {
+                itMask("#;", 0,  "");
+                itMask("#;", 1,  "1");
+                
+                itMask("#;", -1,  "1");
+                itMask("#;", -10, "10");
+            });
+
+            describe("A mask with positive, negative and zero sections: «#;(#);ZERO»", function() {
+                itMask("#;(#);ZERO", 0,    "ZERO");
+                itMask("#;(#);ZERO", 0.4,  "ZERO");
+                itMask("#;(#);ZERO", 0.5,  "1");
+                itMask("#;(#);ZERO", 1,    "1");
+                
+                itMask("#;(#);ZERO", -0.4,  "ZERO");
+                itMask("#;(#);ZERO", -0.5,  "(1)");
+                itMask("#;(#);ZERO", -10,   "(10)");
+            });
+
+            describe("A mask with positive and negative sections, and an empty zero section: «#;(#);» uses the positive section as zero", function() {
+                itMask("#;(#);", 0,    "");
+                itMask("#;(#);", 0.4,  "");
+                itMask("#;(#);", 0.5,  "1");
+                itMask("#;(#);", 1,    "1");
+                
+                itMask("#;(#);", -0.4,  "");
+                itMask("#;(#);", -0.5,  "(1)");
+                itMask("#;(#);", -10,   "(10)");
+            });
+
+            describe("A mask with positive, negative, zero and null sections: «#;(#);ZERO;NULL»", function() {
+                itMask("#;(#);ZERO;NULL", 0,    "ZERO");
+                itMask("#;(#);ZERO;NULL", 0.4,  "ZERO");
+                itMask("#;(#);ZERO;NULL", 0.5,  "1");
+                itMask("#;(#);ZERO;NULL", 1,    "1");
+                
+                itMask("#;(#);ZERO;NULL", -0.4, "ZERO");
+                itMask("#;(#);ZERO;NULL", -0.5, "(1)");
+                itMask("#;(#);ZERO;NULL", -10,  "(10)");
+
+                itMask("#;(#);ZERO;NULL",  null,     "NULL");
+
+                // TODO: review this later
+                itMask("#;(#);ZERO;NULL",  NaN,      "");
+                itMask("#;(#);ZERO;NULL",  Infinity, "");
+                itMask("#;(#);ZERO;NULL", -Infinity, "");
+            });
+
+            describe("A mask with positive, negative and zero sections, and an empty null section: «#;(#);ZERO;» outputs nulls as \"\"", function() {
+                itMask("#;(#);ZERO;",  null, "");
+            });
+        });
+    
+        describe("mixed text content", function() {
+            describe("text content only, does not output the number", function() {
+                itMask("ABC", 0,   "ABC");
+                itMask("ABC", 0.5,  "ABC");
+                itMask("ABC;", -0.5,  "ABC");
+            });
+
+            describe("decimal point is only output if there's at least one actual significant digit in the value", function() {
+                itMask("#-##-0.#:#", 0,     "--0:");
+                itMask("#-##-0.#:#", 10,    "-1-0:");
+                itMask("#-##-0.#:#", 1234,  "1-23-4:");
+            });
+            
+            itMask("#-##-0.#:#", 0.2,   "--0.2:");
+            itMask("#-##-0.#:#", 1.23,  "--1.2:3");
+            itMask("#-##-0.#:#", 1.235, "--1.2:4");
+
+            describe("excess integer significant digits are output by the leftmost 0 or #", function() {
+                itMask("#-##-0.#:#", 12345,  "12-34-5:");
+                itMask("xxx#-##-0.#:#", 12345,  "xxx12-34-5:");
+            });
+
+            describe("negative sign is output at the leftmost position", function() {
+                itMask("xxx#-##-0.#:#", -12345,  "-xxx12-34-5:");
+            });
+        });
+
+        describe("escaping with \\", function() {
+            
+            // text only does not output the number
+            describe("special characters pass literally to the output", function() {
+                itMask('\\#', 0.2, "#");
+                itMask('\\0', 0.2, "0");
+                itMask('\\.', 0.2, ".");
+                itMask('\\,', 0.2, ",");
+                itMask('\\;', 0.2, ";");
+                itMask('\\$', 0.2, "$");
+                itMask('\\%', 0.2, "%");
+                itMask('\\‰', 0.2, "‰");
+                itMask('\\‱', 0.2, "‱");
+            });
+
+            itMask('\\##.#', 0.2, "#.2");
+        });
+
+        describe("escaping with \"\"", function() {
+            // TODO
+        });
+
+        describe("scaling with percent: %, per-mile: ‰, and per-10-mile: ‱\"\"", function() {
+            itMask('0.00%', 0.2, "20.00%");
+            itMask('0.00‰', 0.2, "200.00‰");
+            itMask('0.00‱', 0.2, "2000.00‱");
+
+            itMask('%0.00', 0.2, "%20.00");
+            itMask('‰0.00', 0.2, "‰200.00");
+            itMask('‱0.00', 0.2, "‱2000.00");
+            
+            itMask('0.00\\%', 0.2, "0.20%");
+            itMask('0.00\\‰', 0.2, "0.20‰");
+            itMask('0.00\\‱', 0.2, "0.20‱");
+
+            itMask('0.00%', -0.2, "-20.00%");
+            itMask('0.00‰', -0.2, "-200.00‰");
+            itMask('0.00‱', -0.2, "-2000.00‱");
+        });
+
+        describe("scaling with `,`", function() {
+            itMask('0,.', 1000,     "1");
+            itMask('0,.', 1000000,  "1000");
+            itMask('0,,.', 1000000, "1");
+            
+            itMask('0,.', 500, "1");
+            itMask('0,.', 400, "0");
+            itMask('#,.', 400, "");
+
+            itMask('0,,.',  1500000, "2");
+            itMask('0,,.#', 1500000, "1.5");
+        });
+
+        describe("grouping with `,`", function() {
+            // TODO - still missing the reader function 
+            //        inserting `,` at appropriate positions
+        });
+
+        describe("scientific notation", function() {
+            // TODO
+        });
+
+        describe("currency symbol", function() {
+            // TODO
+        });
+
+        describe("currency USD", function() {
+            // TODO
+        });
+
+        describe("localization", function() {
+            // TODO
         });
     });
 });


### PR DESCRIPTION
- More unit tests
- Fixed issue where masks having only literal text introducing an implicit # in the integer part. This should only happen if a decimal point is found.

@pamval please review.
