### PR TITLE
[CDF-306] - CCC - Lines with a single null-valued series fail to highlight correctly when hovered-over.

### DIFF
--- a/doc/model/charts/common.xml
+++ b/doc/model/charts/common.xml
@@ -93,7 +93,7 @@
             </c:documentation>
         </c:property>
 
-        <c:property name="pointing" type="pvc.options.Pointing" category="Chart > Interaction">
+        <c:property name="pointing" type="pvc.options.Pointing" category="Chart > Interaction" excludeIn="cde">
             <c:documentation>
                 Contains options related to the way the pointing events are handled (ex: over, out).
             </c:documentation>

--- a/doc/model/varia/pointing.xml
+++ b/doc/model/varia/pointing.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="urn:webdetails/com/2012 ../../schema/com_2012.xsd"
         xmlns="http://www.w3.org/1999/xhtml">
 
-    <c:complexType name="Pointing" space="pvc.options" use="any">
+    <c:complexType name="Pointing" space="pvc.options">
         <c:documentation>
             The options documentation class for the pointing behaviours.
         </c:documentation>


### PR DESCRIPTION
- Fixes to JSDoc because of CDE generation.

@pamval please review.
