### PR TITLE
[CDF-315] - CCC - Tipsy tooltip - should use a single instance per chart to avoid frequent showing/hiding

### DIFF
--- a/doc/model/varia/tooltip.xml
+++ b/doc/model/varia/tooltip.xml
@@ -41,6 +41,19 @@
             </c:documentation>
         </c:property>
 
+        <c:property name="animate" type="number" excludeIn="cde">
+            <c:documentation>
+                The duration for the tooltip move animation, in milliseconds.
+
+                A value of <tt>0</tt> disables the move animation.
+
+                The default value depends on
+                the value of <c:link to="pvc.options.Tooltip#followMouse" />.
+                When <tt>false</tt>, the default value is <tt>400</tt> ms.
+                Otherwise, it is <tt>0</tt>, resulting in no animation.
+            </c:documentation>
+        </c:property>
+
         <c:property name="delayIn" type="number" default="200" excludeIn="cde">
             <c:documentation>
                 The delay for the tooltip to show, in milliseconds.

--- a/package-res/ccc/core/base/chart/chart.js
+++ b/package-res/ccc/core/base/chart/chart.js
@@ -400,7 +400,8 @@ def
     },
 
     _tooltipDefaults: {
-        gravity:     's',
+        gravity:      's',
+        animate:      undefined,
         delayIn:      200,
         delayOut:     80, // smoother moving between marks with tooltips, possibly slightly separated
         offset:       2,

--- a/package-res/ccc/core/base/sign/sign.js
+++ b/package-res/ccc/core/base/sign/sign.js
@@ -333,37 +333,28 @@ def.type('pvc.visual.Sign', pvc.visual.BasicSign)
 
     /* TOOLTIP */
     _addPropTooltip: function(ka) {
-        if(this.pvMark.hasTooltip) return;
+        if(this.pvMark.tooltipOptions) return;
 
-        var chart = this.chart,
-            pointingOptions = chart._pointingOptions,
-            tipOptions = def.create(chart._tooltipOptions, def.get(ka, 'options'));
+        var tipsy = this.panel._requireTipsy(),
+            pointingOptions = this.chart._pointingOptions,
+            tipOptions = def.create(this.chart._tooltipOptions, def.get(ka, 'options'));
 
         tipOptions.isLazy = def.get(ka, 'isLazy', true);
 
         var tooltipFormatter = def.get(ka, 'buildTooltip') ||
-                           this._getTooltipFormatter(tipOptions);
+                this._getTooltipFormatter(tipOptions);
         if(!tooltipFormatter) return;
 
-        tipOptions.isEnabled = this._isTooltipEnabled.bind(this);
-
-        var tipsyEvent = def.get(ka, 'tipsyEvent');
-        if(!tipsyEvent) {
-            if(pointingOptions.mode === 'near') {
-                tipsyEvent = 'point';
-                tipOptions.usesPoint = true;
-            } else {
-                tipsyEvent = 'mouseover';
-            }
-        }
+        var tipsyEvent = def.get(ka, 'tipsyEvent') ||
+                (pointingOptions.mode === 'near' ? 'point' : 'mouseover');
 
         this.pvMark
             .localProperty('tooltip'/*, Function | String*/)
             .tooltip(this._createTooltipProp(tooltipFormatter, tipOptions.isLazy))
             .title(def.fun.constant('')) // Prevent browser tooltip
             .ensureEvents()
-            .event(tipsyEvent, pv.Behavior.tipsy(tipOptions))
-            .hasTooltip = true;
+            .event(tipsyEvent, tipsy)
+            .tooltipOptions = tipOptions;
     },
 
     _getTooltipFormatter: function(tipOptions) { return this.panel._getTooltipFormatter(tipOptions); },

--- a/package-res/ccc/plugin/pie/pie-slice-sign.js
+++ b/package-res/ccc/plugin/pie/pie-slice-sign.js
@@ -16,9 +16,11 @@ pv.PieSlice.prototype = pv.extend(pv.Wedge)
 // There's already a Wedge#midAngle method
 // but it doesn't work well when end-angle isn't explicitly set,
 // so we override the method.
+var normAngle = pv.Shape.normalizeAngle;
+
 pv.PieSlice.prototype.midAngle = function() {
     var instance = this.instance();
-    return instance.startAngle + (instance.angle / 2);
+    return normAngle(instance.startAngle) + normAngle(instance.angle) / 2;
 };
 
 pv.PieSlice.prototype.defaults = new pv.PieSlice()
@@ -37,7 +39,7 @@ def.type('pvc.visual.PieSlice', pvc.visual.Sign)
     this.base(panel, pvMark, keyArgs);
 
     this._activeOffsetRadius = def.get(keyArgs, 'activeOffsetRadius', 0);
-    this._maxOffsetRadius = def.get(keyArgs, 'maxOffsetRadius', 0);
+    this._maxOffsetRadius   = def.get(keyArgs, 'maxOffsetRadius', 0);
     this._resolvePctRadius = def.get(keyArgs, 'resolvePctRadius');
     this._center = def.get(keyArgs, 'center');
 

--- a/package-res/lib/protovis.js
+++ b/package-res/lib/protovis.js
@@ -11,7 +11,7 @@
  * the license for the specific language governing your rights and limitations.
  */
  /*! Copyright 2010 Stanford Visualization Group, Mike Bostock, BSD license. */
- /*! 1c6953b7d7fc4a9b86cf397fb7599cd0a340500e */
+ /*! fc0c0de8aee72bf073d348116373c8cd6262c2b9 */
 /**
  * @class The built-in Array class.
  * @name Array
@@ -6088,6 +6088,7 @@ pv.histogram = function(data, f) {
     var cos   = Math.cos;
     var sin   = Math.sin;
     var sqrt  = Math.sqrt;
+    var pi2   = Math.PI*2;
     var atan2Norm = pv.Shape.atan2Norm;
     var normalizeAngle = pv.Shape.normalizeAngle;
     
@@ -6125,8 +6126,11 @@ pv.histogram = function(data, f) {
         var dy = p.y - this.y ;
         var r  = sqrt(dx*dx + dy*dy);
         if(r >= this.innerRadius &&  r <= this.outerRadius){
-            var a  = atan2Norm(dy, dx); // between -pi and pi -> 0 - 2*pi
-            return this.startAngle <= a && a <= this.endAngle;
+            var a = atan2Norm(dy, dx); // between -pi and pi -> 0 - 2*pi
+            // ex:  45º -> 270º       ?  a = 50º
+            // ex: 300º -> 420º (60º) ?  a = 50º (410º)
+            return (this.startAngle <= a && a <= this.endAngle) ||
+                   (a+=pi2, (this.startAngle <= a && a <= this.endAngle));
         }
         
         return false;

--- a/package-res/lib/tipsy.css
+++ b/package-res/lib/tipsy.css
@@ -62,10 +62,10 @@
                  </td>
 
                  <td class="ccc-tt-dimRoles">
-                    <span class="ccc-tt-roleLabel ...">
+                    <span class="ccc-tt-role ...">
                         * ccc-tt-role-<role name>
-
-                        <span>Value</span>
+                        <span class="ccc-tt-roleIcon"></span>
+                        <span class="ccc-tt-roleLabel">Value</span>
                     </span>
                     ...
                  </td>
@@ -93,31 +93,15 @@
 */
 
 .ccc-tt {
-    position:relative; /* important to achieve a colSpan effect in the dimSep  */
-
-    /*
-        Ensure long words break if necessary.
-        http://kenneth.io/blog/2012/03/04/word-wrapping-hypernation-using-css/
-    */
-    -ms-word-break: break-all;
-    word-break: break-all;
-
-    /* Non standard for webkit */
-    word-break: break-word;
-
-    -webkit-hyphens: auto;
-    -moz-hyphens: auto;
-    -ms-hyphens: auto;
-    hyphens: auto;
-
-    /* If it still overflows, hide */
+    /* If it overflows, hide */
     overflow: hidden;
 }
 
 .ccc-tt-ds {
     border-collapse: collapse;
-    border-spacing: 0;
-    text-align: left;
+    border-spacing:  0;
+    text-align:      left;
+    line-height:     1.5em;
 }
 
 .ccc-tt-ds tr {
@@ -126,22 +110,21 @@
 
 .ccc-tt-ds tr td {
     padding: 0;
-    height: 1.5em; /* works as if min-height */
 }
 
 /* ----------------
      dimLabel
    ---------------- */
 .ccc-tt-ds .ccc-tt-dimLabel {
-    font-weight: bold;
-    color:       darkgray;
+    font-weight:   600;
+    color:         darkgray;
     padding-right: 0.3em;
-    _white-space: nowrap;
+    white-space:   nowrap;
 }
 
 /* Add a Sum sign before measures that were aggregated by summing */
 .ccc-tt-ds .ccc-tt-dimAgg-sum .ccc-tt-dimLabel span:before {
-    content:     "\03a3\00a0"; /* 03a3 - the math n-ary sum; &sum; alternatives: 2211 or 2140 | followed by nbsp  */
+    content:     "\03a3\00a0"; /* 03a3 - the math n-ary sum; followed by nbsp  */
     font-weight: normal;
     font-style:  normal;
     font-size:   1.1em;
@@ -149,7 +132,7 @@
 
 /* Add a Union sign before dimensions that were aggregated by listing */
 .ccc-tt-ds .ccc-tt-dimAgg-list .ccc-tt-dimLabel span:before {
-    content:     "\22c3\00a0"; /* 222a union math symbol; alternative: 22C3  | followed by nbsp */
+    content:     "\22c3\00a0"; /* 222a union math symbol; followed by nbsp */
     font-weight: normal;
     font-style:  normal;
     font-size:   1.2em;
@@ -160,7 +143,7 @@
      dimDatumCount
    ---------------- */
 .ccc-tt-ds .ccc-tt-datumCount span:before {
-    content: "\0023\00a0"; /* 0023 - number sign; 266f - unicode sharp sign | followed by nbsp */
+    content:     "\0023\00a0"; /* 0023 - number sign; followed by nbsp */
     color:       darkgray;
     font-weight: normal;
     font-size:   1.1em;
@@ -170,10 +153,12 @@
      trendLabel
    ---------------- */
 .ccc-tt-ds .ccc-tt-trendLabel {
-    font-size:   1.1em;
-    color:       darkgray;
+    font-size:   1.2em;
     font-weight: bold;
-    /*text-align: center;*/
+}
+
+.ccc-tt-ds .ccc-tt-trendLabel td {
+    padding-bottom: 0.2em;
 }
 
 /* ----------------
@@ -181,44 +166,44 @@
    ---------------- */
 
 .ccc-tt-ds .ccc-tt-dimRoles {
-    text-align: center;
-    padding-left: 0.3em;
+    text-align:    center;
+    padding-left:  0.3em;
     padding-right: 0.3em;
 }
 
-.ccc-tt-ds .ccc-tt-roleLabel span {
-    /* Hide all visual role labels, by default; show only symbols in place of. */
+.ccc-tt-ds .ccc-tt-roleLabel {
+    /* Hide all visual role labels, by default; show only icons in place of. */
     display: none;
 }
 
 /* Display x, y and value visual roles as horizontal and vertical arrows */
-.ccc-tt-ds.ccc-tt-chartOrient-v .ccc-tt-role-x:after,
-.ccc-tt-ds.ccc-tt-chartOrient-h .ccc-tt-role-y:after,
-.ccc-tt-ds.ccc-tt-chartOrient-h .ccc-tt-role-value:after {
+.ccc-tt-ds.ccc-tt-chartOrient-v .ccc-tt-role-x     .ccc-tt-roleIcon:after,
+.ccc-tt-ds.ccc-tt-chartOrient-h .ccc-tt-role-y     .ccc-tt-roleIcon:after,
+.ccc-tt-ds.ccc-tt-chartOrient-h .ccc-tt-role-value .ccc-tt-roleIcon:after {
     content:   "\2194"; /* &harr; */
     font-size: 1.2em;
 }
 
-.ccc-tt-ds.ccc-tt-chartOrient-v .ccc-tt-role-y:after,
-.ccc-tt-ds.ccc-tt-chartOrient-h .ccc-tt-role-x:after,
-.ccc-tt-ds.ccc-tt-chartOrient-v .ccc-tt-role-value:after {
+.ccc-tt-ds.ccc-tt-chartOrient-v .ccc-tt-role-y     .ccc-tt-roleIcon:after,
+.ccc-tt-ds.ccc-tt-chartOrient-h .ccc-tt-role-x     .ccc-tt-roleIcon:after,
+.ccc-tt-ds.ccc-tt-chartOrient-v .ccc-tt-role-value .ccc-tt-roleIcon:after {
     content:   "\2195"; /* unicode vertical arrow */
     font-size: 1.2em;
 }
 
-.ccc-tt-ds.ccc-tt-plot-pie .ccc-tt-role-value:after,
-.ccc-tt-ds.ccc-tt-plot-sunburst .ccc-tt-role-size:after {
-    content:   "\2220"; /* 2220 - angle; 25d4 - CIRCLE WITH UPPER RIGHT QUADRANT BLACK */
+.ccc-tt-ds.ccc-tt-plot-pie      .ccc-tt-role-value .ccc-tt-roleIcon:after,
+.ccc-tt-ds.ccc-tt-plot-sunburst .ccc-tt-role-size  .ccc-tt-roleIcon:after {
+    content:   "\2220"; /* 2220 - angle */
     font-size: 1.5em;
 }
 
-.ccc-tt-ds .ccc-tt-role-multiChart:after {
-    content:   "\229e"; /* 229e - unicode squared plus \25A2-rounded square "\253c\20de" */
+.ccc-tt-ds  .ccc-tt-role-multiChart .ccc-tt-roleIcon:after {
+    content:   "\229e"; /* 229e - unicode squared plus */
     font-size: 1.2em;
 }
 
 /* No browser support yet for second argument of attr function.
-.ccc-tt-ds .ccc-tt-role-color .ccc-tt-roleLabel:after {
+.ccc-tt-ds .ccc-tt-role-color .ccc-tt-roleIcon:after {
     content: "\25a3";
     color:   attr(data-ccc-color color);
 }


### PR DESCRIPTION
- A single tooltip instance is used per chart.
- Tooltip options are stored in each mark and read by tipsy, overriding construction options.
- New tooltip.animate option, for move animation, added to jquery.tipsy.
- Tooltip markup adds a tag for the visual role icon, to avoid the need for content replacement in CSS.
- Fixed tooltip percentage text breaking into a new line.
- Fixed protovis bug in detecting if a wedge contains a point.
- Fixed tooltip CSS line height problems.
- JsDocs

@pamval please review.
