### PR TITLE
[CDF-377] - CCC - Fix tooltip opacity options documentation.

### DIFF
--- a/doc/model/varia/tooltip.xml
+++ b/doc/model/varia/tooltip.xml
@@ -77,10 +77,7 @@
 
         <c:property name="opacity" type="number" default="0.9">
             <c:documentation>
-                The distance of the closest tooltip edge or corner
-                to the visual element's tooltip anchor point.
-
-                The default value depends on the chart type.
+                The opacity level of the tooltip box (range from 0, completely transparent, to 1).
             </c:documentation>
         </c:property>
 


### PR DESCRIPTION
Reworded the proposed description in https://github.com/webdetails/cde/pull/135 cause the properties xml generator only grabs the text till the first ".".
@pamval please review.
