### PR TITLE
[BACKLOG-833] - The head grid chart doesn't change based on the positive...

### DIFF
--- a/package-res/ccc/plugin/heatGrid/hg-plot.js
+++ b/package-res/ccc/plugin/heatGrid/hg-plot.js
@@ -27,7 +27,7 @@ def
         // TODO: get a translator for this!!
 
         var chart = this.chart,
-            sizeDimName = (chart.compatVersion() <= 1 && chart.options.sizeValIdx === 1)
+            sizeDimName = (chart.compatVersion() > 1 || chart.options.sizeValIdx === 1)
                 ? 'value2'
                 : 'value';
 


### PR DESCRIPTION
...,negative data of table.
- The default dimension name for the "size" visual role had regressed, from "value2" to "value".

@pamval please review.
