### PR TITLE
[CDF-380] - CCC - HeatGrid - A null size value and a non-null color valu...

### DIFF
--- a/package-res/ccc/plugin/heatGrid/hg-plot-panel.js
+++ b/package-res/ccc/plugin/heatGrid/hg-plot-panel.js
@@ -230,9 +230,13 @@ def
     _createShapesHeatMap: function(cellSize, wrapper, hasColor, hasSize) {
         var me = this,
             // SIZE
-            areaRange = me._calcDotAreaRange(cellSize),
-            // Dot Sign
-            keyArgs = {
+            areaRange = me._calcDotAreaRange(cellSize);
+
+        // NOTE: this has to be done before new pvc.visual.DotSizeColor!
+        if(hasSize) me.axes.size.setScaleRange(areaRange);
+
+        // Dot Sign
+        var keyArgs = {
                 extensionId: 'dot',
                 freePosition: true,
                 activeSeriesAware: false,
@@ -249,8 +253,7 @@ def
                 // The radius calculation code should be improved?
                 //.lock('shapeAngle');
 
-        if(hasSize) me.axes.size.setScaleRange(areaRange);
-        else pvDot.sign.override('defaultSize', def.fun.constant(areaRange.max));
+        if(!hasSize) pvDot.sign.override('defaultSize', def.fun.constant(areaRange.max));
 
         return pvDot;
     },


### PR DESCRIPTION
...e no longer show a colored null symbol (cross) instead.
- Another refactoring that went wrong, by changing the order of execution of something to after it was needed.

@pamval please review.
