### PR TITLE
[CDF-405] -  CCC - Options to control the minimum and maximum precision/units of temporal ticks

### DIFF
--- a/examples/pvcTest.html
+++ b/examples/pvcTest.html
@@ -469,23 +469,11 @@
                     legend: true,
                     legendPosition: "top",
                     legendAlign: "right",
-                    //legendSize: null,
-
-                    orientation: 'vertical',
-                    
                     dimensions: { category: {valueType: Date, rawFormat: "%Y-%m-%d", format: "%Y-%m-%d" } },
-
-                    
-                    valuesVisible: false,
-                    originIsZero: false,
                     dotsVisible: true,
-                    yAxisSize: 40,
-                    xAxisSize: 30,
-                    xAxisGrid: true,
-                    yAxisGrid: true,
+                    axisGrid: true,
                     extensionPoints: {
                         titleLabel_font: "13px serif",
-                        //dot_strokeStyle: "white",
                         dot_fillStyle: "white",
                         dot_shape: "square",
                         dot_lineWidth: 2,
@@ -512,21 +500,11 @@
                     legend: true,
                     legendPosition: "top",
                     legendAlign: "right",
-                    //legendSize: null,
-
-                    orientation: 'vertical',
-                    
                     dimensions: { category: {valueType: Date, rawFormat: "%Y-%m-%d", format: "%Y-%m-%d" } },
-                    
-                    valuesVisible: false,
                     dotsVisible: true,
-                    yAxisSize: 30,
-                    xAxisSize: 30,
-                    xAxisGrid: true,
-                    yAxisGrid: true,
+                    axisGrid: true,
                     extensionPoints: {
                         titleLabel_font: "13px serif",
-                        //dot_strokeStyle: "white",
                         dot_fillStyle: "white",
                         dot_shape: "square",
                         dot_lineWidth: 2,
@@ -551,22 +529,11 @@
                     legend: true,
                     legendPosition: "top",
                     legendAlign: "right",
-                    //legendSize: null,
-
-                    orientation: 'vertical',
-                    
                     dimensions: { category: {valueType: Date, rawFormat: "%Y-%m-%d", format: "%Y-%m-%d" } },
-                    
-                    valuesVisible: false,
-
                     dotsVisible: true,
-                    yAxisSize: 30,
-                    xAxisSize: 30,
-                    xAxisGrid: true,
-                    yAxisGrid: true,
+                    axisGrid: true,
                     extensionPoints: {
                         titleLabel_font: "13px serif",
-                        //dot_strokeStyle: "white",
                         dot_fillStyle: "white",
                         dot_shape: "square",
                         dot_lineWidth: 2,

--- a/examples/pvcTestBar.html
+++ b/examples/pvcTestBar.html
@@ -524,6 +524,7 @@ new pvc.BarChart({
     orientation: 'horizontal',
     colorMap: {'Paris': 'pink'},
     stacked: true,
+    timeSeries: true,
     animate: false,
     legend:  true,
     legendPosition: 'top',

--- a/package-res/ccc/core/cartesian/cart-chart.js
+++ b/package-res/ccc/core/cartesian/cart-chart.js
@@ -222,7 +222,6 @@ def
                 gridCrossesMargin: axis.option('GridCrossesMargin'),
                 ruleCrossesMargin: axis.option('RuleCrossesMargin'),
                 zeroLine:          axis.option('ZeroLine'),
-                desiredTickCount:  axis.option('DesiredTickCount'),
                 showTicks:         axis.option('Ticks'),
                 showMinorTicks:    axis.option('MinorTicks')
             });
@@ -292,7 +291,7 @@ def
     },
 
     _coordinateSmallChartsLayout: function(scopesByType) {
-        // TODO: optimize the case were
+        // TODO: optimize the case where
         // the title panels have a fixed size and
         // the x and y FixedMin and FixedMax are all specified...
         // Don't need to coordinate in that case.

--- a/package-res/ccc/core/cartesian/cart-dockingGrid-panel.js
+++ b/package-res/ccc/core/cartesian/cart-dockingGrid-panel.js
@@ -63,8 +63,9 @@ def
             oend_a = this.anchorOpposite(obeg_a),
             mainPlot = this.chart.plotPanelList[0],
             tick_offset = axis.orientation === 'x'
-                ? (mainPlot.position.left   + paddings.left  )
-                : (mainPlot.position.bottom + paddings.bottom),//margins[tick_a] + paddings[tick_a],
+                // mainPlot.isVisible ?
+                ? ((mainPlot.position.left   || 0) + paddings.left  )
+                : ((mainPlot.position.bottom || 0) + paddings.bottom), //margins[tick_a] + paddings[tick_a],
             obeg = margins[obeg_a],
             oend = margins[oend_a],
             tickScenes = rootScene.leafs().array(),

--- a/package-res/lib/protovis.js
+++ b/package-res/lib/protovis.js
@@ -11,7 +11,7 @@
  * the license for the specific language governing your rights and limitations.
  */
  /*! Copyright 2010 Stanford Visualization Group, Mike Bostock, BSD license. */
- /*! 768355af752a630a2d4ab77325e4615f619128c1 */
+ /*! f8be68ce5b70f1365f225f811ed23d0cafcc3259 */
 /**
  * @class The built-in Array class.
  * @name Array
@@ -3668,11 +3668,6 @@ pv.Scale.quantitative = function() {
       usedNumberExponent;
 
   /** @private */
-  function newDate(x) {
-    return new Date(x);
-  }
-
-  /** @private */
   function scale(x) {
     var j = pv.search(d, x);
     if (j < 0) j = -j - 2;
@@ -3827,266 +3822,43 @@ pv.Scale.quantitative = function() {
    *
    * @function
    * @name pv.Scale.quantitative.prototype.ticks
-   * @param {number} [m] optional number of desired numeric ticks.
+   * @param {number} [N] optional number of desired ticks.
+   * When <tt>Infinity</tt>, as many ticks as result from using the precision <i>precisionMin</i>.
+   * If the later is not specified, then the default number of ticks is used anyway.
    * @param {object} [options] optional keyword arguments object.
    * @param {boolean} [options.roundInside=true] should the ticks be ensured to be strictly inside the scale domain, or to strictly outside the scale domain.
-   * @param {boolean} [options.numberExponentMin=-Inifinity] minimum value for the step exponent.
-   * @param {boolean} [options.numberExponentMax=+Inifinity] maximum value for the step exponent.
+   * @param {number} [options.numberExponentMin] minimum value for the step exponent (numeric domain only).
+   * @param {number} [options.numberExponentMax] maximum value for the step exponent (numeric domain only).
+   * @param {number} [options.precision] fixed precision. For dates, overrides the dateTickPrecision property.
+   * @param {number} [options.precisionMin] minimum precision.
+   * @param {number} [options.precisionMax] maximum precision.
+   * @param {number} [options.tickCountMax] maximum number of ticks.
+   *
    * @returns {Array.<number>} an array input domain values to use as ticks.
    */
-  scale.ticks = function(m, options) {
+  scale.ticks = function(N, options) {
     var start = d[0],
-        end = d[d.length - 1],
+        end   = d[d.length - 1],
         reverse = end < start,
         min = reverse ? end : start,
         max = reverse ? start : end,
-        span = max - min;
+        result, ticks;
 
-    /* Special case: empty, invalid or infinite span. */
-    if (!span || !isFinite(span)) {
-      if (type == newDate) tickFormat = pv.Format.date("%x");
-      return [type(min)];
+    if(type === newDate) {
+      result = genDateTicks(N, min, max, dateTickPrecision, dateTickFormat, dateTickWeekStart, options);
+
+      usedDateTickPrecision = result.precision;
+    } else {
+      result = genNumberTicks(N, min, max, options);
+
+      usedNumberExponent = result.decPlaces;
     }
 
-    var roundInside = pv.get(options, 'roundInside', true);
+    ticks = result.ticks;
+    tickFormat = result.format;
 
-    /* Special case: dates. */
-    if (type == newDate) {
-      /* Floor the date d given the precision p. */
-      function floor(d, p) {
-        switch(p) {
-          // NOTE: fall-through!
-          case 31536e6: d.setMonth(0);        // year
-          case 2592e6:  d.setDate(1);         // 30 days
-          case 6048e5:  if(p == 6048e5) {
-            var delta = d.getDay() - dateTickWeekStart;
-            if(delta < 0) delta += 7; // ensure down.
-            if(delta > 0) d.setDate(d.getDate() - delta);
-          } // 7-days dayOfMonth{1,31} - dayOfWeek{0, 6}{Sunday,Saturday}
-          case 864e5:   d.setHours(0);        // day
-          case 36e5:    d.setMinutes(0);      // hour
-          case 6e4:     d.setSeconds(0);      // minute
-          case 1e3:     d.setMilliseconds(0); // second
-        }
-        return d;
-      }
-
-      function firstWeekStartOfMonth(date) {
-        var d = new Date(date.getFullYear(), date.getMonth(), 1);
-        var wd = dateTickWeekStart - d.getDay();
-        if(wd) {
-          if(wd < 0) wd += 7;
-          d.setDate(d.getDate() + wd);
-        }
-        return d;
-      }
-
-      var nn = m == null ? 5 : m;
-      var precision, format, increment, step = 1;
-      if (span >= nn * 31536e6) { // year
-        precision = 31536e6;
-        format = "%Y";
-        /** @ignore */ increment = function(d) { d.setFullYear(d.getFullYear() + step); };
-      } else if (span >= nn * 2592e6) { // month/30d
-        precision = 2592e6;
-        format = "%m/%Y";
-        /** @ignore */ increment = function(d) { d.setMonth(d.getMonth() + step); };
-      } else if (span >= nn * 6048e5) {  // week/7d
-        // TODO: with nn = 5, a 2 days span ends up being shown as 48 hour ticks (except some are skipped)
-        precision = 6048e5;
-        format = "%m/%d";
-        /** @ignore */ increment = function(d) { d.setDate(d.getDate() + 7 * step); };
-      } else if (span >= nn * 864e5) { // day
-        precision = 864e5;
-        format = "%m/%d";
-        /** @ignore */ increment = function(d) { d.setDate(d.getDate() + step); };
-      } else if (span >= nn * 36e5) { // hour
-        precision = 36e5;
-        format = "%I:%M %p";
-        /** @ignore */ increment = function(d) { d.setHours(d.getHours() + step); };
-      } else if (span >= nn * 6e4) { // minute
-        precision = 6e4;
-        format = "%I:%M %p";
-        /** @ignore */ increment = function(d) { d.setMinutes(d.getMinutes() + step); };
-      } else if (span >= nn * 1e3) { // second
-        precision = 1e3;
-        format = "%I:%M:%S";
-        /** @ignore */ increment = function(d) { d.setSeconds(d.getSeconds() + step); };
-      } else { // millisecond
-        precision = 1;
-        format = "%S.%Qs";
-        /** @ignore */ increment = function(d) { d.setTime(d.getTime() + step); };
-      }
-
-      precision = dateTickPrecision ? dateTickPrecision : precision;
-      format = dateTickFormat ? dateTickFormat : format;
-
-      usedDateTickPrecision = precision;
-
-      tickFormat = pv.Format.date(format);
-
-      var date = new Date(min), dates = [];
-      floor(date, precision);
-
-      /* If we'd generate too many ticks, skip some!. */
-      if(!dateTickPrecision) {
-        var n = span / precision;
-        if(n > 10) {
-          switch (precision) {
-            // 1 hour
-            case 36e5: {
-              step = (n > 20) ? 6 : 3;
-              date.setHours(Math.floor(date.getHours() / step) * step);
-              break;
-            }
-
-            // 30 days
-            case 2592e6: {
-              step = (n > 24) ? 3 : ((n > 12) ? 2 : 1);
-              date.setMonth(Math.floor(date.getMonth() / step) * step);
-              break;
-            }
-
-            // 7 day
-            // (nn = 5:
-            //     span >= 35 days (n >= 5)
-            //     span < 150 days (n <  ~21.43)
-            case 6048e5: {
-              // span (days) | n (ticks/weeks) | step     | new n | description
-              // -----------------------------------------------------------------
-              // 106 - 149   | 15 - 22         | 3*7 = 21 | 5 - 7 | 15 weeks, ~3 months
-              //  71 - 105   | 11 - 15         | 2*7 = 14 | 5 - 7 | 11 weeks, ~2.2 months
-              //  35 -  70   |  5 - 10         | 1*7 =  7 |    -  |  5 weeks, ~1 month
-              step = (n > 15) ? 3 : (n > 10 ? 2 : 1);
-              date.setDate(firstWeekStartOfMonth(date).getDate() + Math.floor(date.getDate() / (7 * step)) * (7 * step));
-              break;
-            }
-
-            // 1 day (nn = 5: span >= 5 hours and span < 35 days)
-            // span > 10 days: more than 10 ticks
-            case 864e5: {
-              step = (n >= 30) ? 5 : ((n >= 15) ? 3 : 2);
-              date.setDate(1 + Math.floor(date.getDate() / step) * step);
-              break;
-            }
-
-            // 1 minute
-            case 6e4: {
-              step = (n > 30) ? 15 : ((n > 15) ? 10 : 5);
-              date.setMinutes(Math.floor(date.getMinutes() / step) * step);
-              break;
-            }
-
-            // 1 second
-            case 1e3: {
-              step = (n > 90) ? 15 : ((n > 60) ? 10 : 5);
-              date.setSeconds(Math.floor(date.getSeconds() / step) * step);
-              break;
-            }
-
-            // 1 millisecond
-            case 1: {
-              step = (n > 1000) ? 250 : ((n > 200) ? 100 : ((n > 100) ? 50 : ((n > 50) ? 25 : 5)));
-              date.setMilliseconds(Math.floor(date.getMilliseconds() / step) * step);
-              break;
-            }
-
-            // 31536e6 - 1 year
-            default: {
-              step = pv.logCeil(n / 15, 10);
-              if (n / step < 2) step /= 5;
-              else if (n / step < 5) step /= 2;
-              date.setFullYear(Math.floor(date.getFullYear() / step) * step);
-              break;
-            }
-          }
-        }
-      } else {
-        increment = function(d) { d.setSeconds(d.getSeconds() + dateTickPrecision / 1000); };
-      }
-
-      if(roundInside) {
-  	    while (true) {
-  	      increment(date);
-  	      if (date > max) break;
-    	    dates.push(new Date(date));
-    	  }
-      } else {
-        max = new Date(max);
-        if(floor(new Date(max), precision).getTime() !== max.getTime()) increment(max);
-
-        do {
-  	      dates.push(new Date(date));
-  	      increment(date);
-  	    } while(date <= max);
-      }
-
-      return reverse ? dates.reverse() : dates;
-    }
-
-    /* Normal case: numbers */
-    if (m == null) {
-        m = 10;
-    }
-
-    var exponentMin = pv.get(options, 'numberExponentMin', -Infinity);
-    var exponentMax = pv.get(options, 'numberExponentMax', +Infinity);
-
-    //var step = pv.logFloor(span / m, 10);
-    var exponent = Math.floor(pv.log(span / m, 10));
-    var overflow = false;
-    if(exponent > exponentMax) {
-        exponent = exponentMax;
-        overflow = true;
-    } else if(exponent < exponentMin) {
-        exponent = exponentMin;
-        overflow = true;
-    }
-
-    step = Math.pow(10, exponent);
-    var mObtained = (span / step);
-
-    var err = m / mObtained;
-    if(err <= .15 && exponent < exponentMax - 1) {
-        step *= 10;
-        mObtained /= 10;
-    } else if(err <= .35) {
-        step *= 5;
-        mObtained /= 5;
-    } else if(err <= .75) {
-        step *= 2;
-        mObtained /= 2;
-    }
-
-    // Account for floating point precision errors
-    exponent = Math.floor(pv.log(step, 10) + 1e-10);
-
-    start = step * Math[roundInside ? 'ceil'  : 'floor'](min / step);
-    end   = step * Math[roundInside ? 'floor' : 'ceil' ](max / step);
-
-    usedNumberExponent = Math.max(0, -exponent);
-
-    tickFormat = pv.Format.number().fractionDigits(usedNumberExponent);
-
-    // Handle special case
-    if(m === 2 && mObtained >= 2) {
-      // Take only the first and last
-      step = end - start;
-    }
-
-    var ticks = pv.range(start, end + step, step);
-    if(reverse) { ticks.reverse(); }
-
-    ticks.roundInside = roundInside;
-    ticks.step        = step;
-    ticks.exponent    = exponent;
-    ticks.exponentOverflow = overflow;
-    ticks.exponentMin = exponentMin;
-    ticks.exponentMax = exponentMax;
-
-    return ticks;
+    return reverse ? ticks.reverse() : ticks;
   };
-
 
   /**
    * Formats the specified tick with a well defined string for the date
@@ -4094,23 +3866,37 @@ pv.Scale.quantitative = function() {
    * @name pv.Scale.quantitative.prototype.dateTickFormat
    * @returns {string} a string with the desired tick format.
    */
-  scale.dateTickFormat = function () {
-    if (arguments.length) {
+  scale.dateTickFormat = function() {
+    if(arguments.length) {
       dateTickFormat = arguments[0];
       return this;
     }
-    return dateTickFormat;  };
+    return dateTickFormat;
+  };
 
   /**
    * Generates date ticks with a specified precision.
    * @function
    * @name pv.Scale.quantitative.prototype.dateTickPrecision
-   * @param {number} [precision] The number of milliseconds that separate ticks.
+   * @param {number|string} [precision] The number of milliseconds that separate ticks.
+   * Can be given by the name of a standard time interval,
+   * optionally immediately preceded by an integer (e.g. '30d').
+   * <ul>
+   *   <li>'y' - Year</li>
+   *   <li>'m' - Month</li>
+   *   <li>'w' - Week</li>
+   *   <li>'d' - Day</li>
+   *   <li>'h' - Hour</li>
+   *   <li>'M' - Minute</li>
+   *   <li>'s' - Second</li>
+   *   <li>'ms' - Millisecond</li>
+   * </ul>
+   *
    * @returns {number} the current date tick precision.
    */
   scale.dateTickPrecision = function () {
     if (arguments.length) {
-      dateTickPrecision = arguments[0];
+      dateTickPrecision = parseDatePrecision(arguments[0], 0);
       return this;
     }
     return dateTickPrecision;
@@ -4123,7 +3909,8 @@ pv.Scale.quantitative = function() {
    *
    * @function
    * @name pv.Scale.quantitative.prototype.dateTickWeekStart
-   * @param {number} [weekStart] The day of the week.
+   * @param {number|string} [weekStart] The day of the week.
+   * Either the name of the week day or the following numbers can be specified.
    * <ul>
    *   <li>0 - Sunday</li>
    *   <li>1 - Monday</li>
@@ -4135,34 +3922,42 @@ pv.Scale.quantitative = function() {
    * </ul>
    * @returns {number} the current start day of the week.
    */
-  scale.dateTickWeekStart = function () {
-    if (arguments.length) {
-      dateTickWeekStart = arguments[0];
+  scale.dateTickWeekStart = function(weekStart) {
+    if(arguments.length) {
+      switch((''+weekStart).toLowerCase()) {
+        case '0':case 'sunday':    dateTickWeekStart = 0; break;
+        case '1':case 'monday':    dateTickWeekStart = 1; break;
+        case '2':case 'tuesday':   dateTickWeekStart = 2; break;
+        case '3':case 'wednesday': dateTickWeekStart = 3; break;
+        case '4':case 'thursday':  dateTickWeekStart = 4; break;
+        case '5':case 'friday':    dateTickWeekStart = 5; break;
+        case '6':case 'saturday':  dateTickWeekStart = 6; break;
+        default: dateTickWeekStart = 0; break;
+      }
       return this;
     }
     return dateTickWeekStart;
   };
 
+  /**
+   * Gets or sets a custom tick formatter function.
+   *
+   * @function
+   * @name pv.Scale.quantitative.prototype.tickFormatter
+   * @param {?(function((number|Date)):string)=} f The function that formats number or date ticks.
+   * When ticks are dates, the second argument of the function is the
+   * desired tick precision.
+   *
+   * @returns {pv.Scale|function((number|Date)):string} a custom formatter function or this instance.
+   */
+  scale.tickFormatter = function (f) {
+    if (arguments.length) {
+      tickFormatter = f;
+      return this;
+    }
 
-    /**
-     * Gets or sets a custom tick formatter function.
-     *
-     * @function
-     * @name pv.Scale.quantitative.prototype.tickFormatter
-     * @param {?(function((number|Date)):string)=} f The function that formats number or date ticks.
-     * When ticks are dates, the second argument of the function is the
-     * desired tick precision.
-     *
-     * @returns {pv.Scale|function((number|Date)):string} a custom formatter function or this instance.
-     */
-    scale.tickFormatter = function (f) {
-      if (arguments.length) {
-        tickFormatter = f;
-        return this;
-      }
-
-      return tickFormatter;
-   };
+    return tickFormatter;
+  };
 
   /**
    * Formats the specified tick value using the appropriate precision, based on
@@ -4176,7 +3971,7 @@ pv.Scale.quantitative = function() {
    */
   scale.tickFormat = function (t) {
       var text;
-      if(tickFormatter){
+      if(tickFormatter) {
           text = tickFormatter(t, type !== Number ? usedDateTickPrecision : usedNumberExponent);
       } else {
           text = tickFormat(t);
@@ -4249,6 +4044,786 @@ pv.Scale.quantitative = function() {
   scale.domain.apply(scale, arguments);
   return scale;
 };
+
+// -----------
+// NUMBER
+function genNumberTicks(N, min, max, options) {
+  var span = max - min;
+
+  // Special case: empty, invalid or infinite span.
+  if(!span || !isFinite(span))
+    return {
+      format:    pv.Format.number().fractionDigits(0),
+      decPlaces: 0,
+      ticks:     [+min]
+    };
+
+  var precision    = pv.parseNumNonNeg(pv.get(options, 'precision',    0)),
+      precisionMin = pv.parseNumNonNeg(pv.get(options, 'precisionMin', 0)),
+      precisionMax = pv.parseNumNonNeg(pv.get(options, 'precisionMax', Infinity));
+
+  if(!isFinite(precision)) precision = 0;
+  if(!isFinite(precisionMin)) precisionMin = 0;
+  if(!precisionMax) precisionMax = Infinity;
+
+
+  // Combine exponent and precision constraints
+  var exponentMin = pv.get(options, 'numberExponentMin'),
+      exponentMax = pv.get(options, 'numberExponentMax');
+
+  if(exponentMin != null && isFinite(exponentMin))
+    precisionMin = Math.max(precisionMin, Math.pow(10, Math.floor(exponentMin)));
+
+  // Highest multiplier is always 5, for any given base precision.
+  if(exponentMax != null && isFinite(exponentMax))
+    precisionMax = Math.min(precisionMax, 5 * Math.pow(10, Math.floor(exponentMax)));
+
+  if(precisionMax < precisionMin) precisionMax = precisionMin;
+
+  if(precision)
+    precision = Math.max(Math.min(precision, precisionMax), precisionMin);
+  else if(precisionMin === precisionMax)
+    precision = precisionMin;
+
+  // ------
+
+  var overflow = 0, // no overflow
+      fixed = !!precision,
+      result, precMin, precMax, NObtained;
+
+  if(fixed) {
+    result = {
+      base:  Math.abs(precision),
+      mult:  1,
+      value: 1
+    };
+    result.value = result.base;
+  } else {
+    var NMax = pv.parseNumNonNeg(pv.get(options, 'tickCountMax', Infinity));
+    if(NMax < 2) NMax = 2;
+
+    // When N is Infinite, it means, use precisionMin or tickCountMax.
+    // If precisionMin is not defined, then N is defaulted to 10, anyway...
+    if(N == null)
+      N = Math.min(10, NMax);
+    else if(!isFinite(N))
+      N = isFinite(NMax) ? NMax : 10;
+    else if(N > NMax)
+      N = NMax;
+
+    result = {
+      base:  isFinite(N) ? pv.logFloor(span / N, 10) : 0,
+      mult:  1,
+      value: 1
+    };
+    result.value = result.base;
+
+    // Maintain the base-precision within constraints.
+    if(precisionMin > 0) {
+      precMin = readNumberPrecision(precisionMin, /*isMin*/true);
+      if(result.value < precMin.value) {
+        numberCopyResult(result, precMin);
+        overflow = -1;
+      }
+    }
+
+    if(isFinite(precisionMax)) {
+      precMax = readNumberPrecision(precisionMax, /*isMin*/false);
+      if(precMin && precMax.value <= precMin.value) {
+        precMax = null;
+      } else if(precMax.value < result.value) {
+        numberCopyResult(result, precMax);
+        overflow = 1;
+      }
+    }
+
+    // If we'd obtain "many" more ticks than desired,
+    // reduce the number of ticks,
+    // by only generating ticks for multiples (2,5,10) of the base precision.
+    if(isFinite(N)) {
+      NObtained = span / result.value;
+      if(N < NObtained) {
+        var err = N / NObtained;
+
+        if(err <= .15) result.mult = 10;
+        else
+        if(err <= .35) result.mult = 5;
+        else
+        if(err <= .75) result.mult = 2;
+
+        if(result.mult > 1) {
+          result.value = result.base * result.mult;
+          NObtained /= result.mult;
+
+          if(precMin && result.value < precMin.value) {
+            numberCopyResult(result, precMin);
+            overflow = -1;
+            NObtained = span / result.value;
+          } else if(precMax && precMax.value < result.value) {
+            numberCopyResult(result, precMax);
+            overflow = 1;
+            NObtained = span / result.value;
+          } else if(result.mult === 10) {
+            // Now it's worth fixing this.
+            result.base *= 10;
+            result.mult = 1;
+          }
+        }
+      }
+    }
+  } // if fixed else
+
+  var roundInside = pv.get(options, 'roundInside', true),
+      resultPrev;
+
+  while(true) {
+    var step  = result.value,
+        start = step * Math[roundInside ? 'ceil'  : 'floor'](min / step),
+        end   = step * Math[roundInside ? 'floor' : 'ceil' ](max / step);
+
+    if(resultPrev && precMax && (end - start) > precMax.value) {
+      result = resultPrev;
+      break;
+    }
+
+    // Account for floating point precision errors.
+    var exponent = Math.floor(pv.log(step, 10) + 1e-10);
+
+    result.decPlaces = Math.max(0, -exponent);
+
+    // Generates at least 2 ticks.
+    // For cases with negative and positive data, generates at least 3 ticks, whatever the step.
+    result.ticks = pv.range(start, end + step, step);
+
+    // NMax >= 2
+    if(fixed || overflow > 0 || result.ticks.length <= NMax) break;
+
+    if(resultPrev && resultPrev.ticks.length <= result.ticks.length) {
+      result = resultPrev;
+      break;
+    }
+
+    result = numberResultAbove((resultPrev = result));
+  }
+
+  var ticks = result.ticks;
+  ticks.step = result.value;
+
+  return {
+    format:    pv.Format.number().fractionDigits(result.decPlaces),
+    decPlaces: result.decPlaces,
+    ticks:     ticks
+  };
+}
+
+function numberCopyResult(to, from) {
+  to.base  = from.base;
+  to.mult  = from.mult;
+  to.value = from.value;
+  return to;
+}
+
+function numberResultAbove(result) {
+  var out = numberCopyResult({}, result);
+  switch(out.mult) {
+    case 5: out.mult = 1; out.base *= 10; break;
+    case 2: out.mult = 5; break;
+    case 1: out.mult = 2; break;
+  }
+  out.value = out.base * out.mult;
+  return out;
+}
+
+function readNumberPrecision(precision, isMin) {
+  if(precision < 0) precision = -precision;
+
+  var base = pv.logFloor(precision, 10),
+      mult = precision / base;
+
+  if(!isMin) { // floor
+    if(mult >= 5) mult = 5;
+    else if(mult >= 2) mult = 2;
+    else mult = 1;
+  } else { // ceil
+    if(mult > 5) mult = 1, base *= 10;
+    else if(mult > 2) mult = 5;
+    else if(mult > 1) mult = 2;
+    else mult = 1;
+  }
+
+  return {
+    base:   base,
+    mult:   mult,
+    value:  base * mult,
+    source: precision
+  };
+}
+
+// -----------
+// DATE
+function newDate(x) {
+  return new Date(x);
+}
+
+function genDateTicks(N, min, max, precision, format, weekStart, options) {
+  var span = max - min, ticks;
+  if(!span || !isFinite(span)) {
+    format = pv.Format.date("%x");
+    precision = 1; // arbitrary value
+    ticks = [newDate(min)];
+  } else {
+
+    // -- Harmonize precision, precisionMin and precisionMax.
+    precision = parseDatePrecision(pv.get(options, 'precision'), precision);
+
+    var precisionMin = parseDatePrecision(pv.get(options, 'precisionMin'), 0),
+        precisionMax = parseDatePrecision(pv.get(options, 'precisionMax'), Infinity);
+
+    if(precisionMax < precisionMin) precisionMax = precisionMin;
+
+    if(precision)
+      precision = Math.max(Math.min(precision, precisionMax), precisionMin);
+    else if(precisionMin === precisionMax)
+      precision = precisionMin;
+
+    var NMax = pv.parseNumNonNeg(pv.get(options, 'tickCountMax', Infinity));
+    if(NMax < 2) NMax = 2;
+
+    // Although `N` can be specified, all values are fine-tuned for N = 5 ...
+    N = Math.min(N == null ? 5 : N, NMax);
+
+    // -- Choose precision and multiple of.
+    var keyArgs  = {
+        weekStart:   weekStart,
+        roundInside: pv.get(options, 'roundInside', 1) // for #ticks method
+      },
+      precResult = chooseDatePrecision(N, span, precision, precisionMin, precisionMax, keyArgs),
+      fixed = precResult.fixed,
+      overflow = precResult.overflow;
+
+    // -- Generate ticks.
+    var precResultPrev;
+
+    while(true) {
+      precResult.ticks = ticks = precResult.comp.ticks(min, max, precResult.mult, keyArgs);
+
+      if(precResultPrev && precResult.precMax && (ticks[ticks.length - 1] - ticks[0]) > precResult.precMax.value) {
+        precResult = precResultPrev;
+        break;
+      }
+
+      // NMax >= 2
+      if(fixed || overflow > 0 || precResult.ticks.length <= NMax) break;
+
+      if(precResultPrev && precResultPrev.ticks.length <= precResult.ticks.length) {
+        precResult = precResultPrev;
+        break;
+      }
+
+      precResultPrev = precResult;
+      precResult = precResult.comp.resultAbove(precResult.mult);
+    }
+
+    ticks = precResult.ticks;
+    precision = ticks.step = precResult.value;
+    format = parseTickDateFormat(format) || precResult.comp.format;
+  }
+
+  return {
+    format:    format,
+    precision: precision,
+    ticks:     ticks
+  };
+}
+
+// -- Determine precision and multiple of.
+function chooseDatePrecision(N, span, precision, precisionMin, precisionMax, options) {
+  var overflow = 0,
+      mult     = 1,
+      fixed    = !!precision,
+      dateComp, castResult, precMin, precMax;
+
+  if(precision) {
+    // Fixed precision.
+    // Obtain the greatest standard precision that is less than or equal to the fixed precision.
+    // Recognizes multiples of standard precisions as well.
+    castResult = readDatePrecision(precision, /*ceil*/false);
+    if(castResult.value !== precision) {
+      // Custom precision.
+      // Because the castResult's standard precision is less than `precision`,
+      // we're sure to have a format mask that outputs less significance parts.
+      // Although it can leave out some relevant more significant ones...
+      dateComp = castResult.comp.withPrecision(precision);
+      // mult = 1
+    } else {
+      // Standard precision, or multiple of.
+      dateComp = castResult.comp;
+      mult     = castResult.mult;
+    }
+  } else {
+    // Variable/Auto precision.
+    // Find the tick component that at the desired tick count, best fits a given span.
+    if(isFinite(N)) {
+      dateComp = getGreatestLessOrEqualDateComp(span, N);
+
+      // If we'd generate too many ticks, skip some.
+      mult = dateComp.multiple(span / dateComp.value, options);
+    } else {
+      // Use lowest possible precision.
+      // precisionMin should also be specified.
+      dateComp = lowestPrecisionValueDateComp();
+      mult     = 1;
+    }
+
+    precision = dateComp.value * mult;
+
+    if(precision    < precisionMin) precMin = readDatePrecision(precisionMin, /*ceil*/true );
+    if(precisionMax < precision   ) precMax = readDatePrecision(precisionMax, /*ceil*/false);
+
+    if(precMin && precision < precMin.value) {
+      dateComp = precMin.comp;
+      mult     = precMin.mult;
+      overflow = -1;
+    } else if(precMax && (precisionMin < precMax.value) && precMax.value < precision) {
+      dateComp = precMax.comp;
+      mult     = precMax.mult;
+      overflow = +1;
+    }
+  }
+
+  return {
+    comp:     dateComp,
+    mult:     mult,
+    value:    dateComp.value * mult,
+    source:   precision,
+    overflow: overflow,
+    fixed:    fixed,
+    precMin:  precMin,
+    precMax:  precMax
+  };
+}
+
+function readDatePrecision(precision, ceil) {
+  if(precision == null || precision <= 0 || !isFinite(precision)) return null;
+
+  return (ceil ? lowestPrecisionValueDateComp : highestPrecisionValueDateComp)()
+    .castValue(precision, /*ceil*/ceil);
+}
+
+// -----------
+var dateCompCopyArgs = ['get', 'set', 'multiple', 'multiples', 'thresholds', 'closeds', 'castValue'];
+
+function DateComponent(value, prev, keyArgs) {
+  this.value  = value;
+  this.mult   = keyArgs.mult || 1; // multiplier from component unit/value to base unit. E.g.: week = 7 * day; mult = 7;
+  this.base   = this.mult === 1 ? this.value : Math.floor(this.value / this.mult);
+
+  dateCompCopyArgs.forEach(function(p) {
+    if(keyArgs[p] != null) this[p] = keyArgs[p];
+  }, this);
+
+  if(keyArgs.floor) this.floorLocal = keyArgs.floor;
+  this.format = parseTickDateFormat(keyArgs.format);
+  this.first  = pv.functor(keyArgs.first || 0); // in base unit
+  this.prev   = prev;
+  this.next   = null;
+
+  if(prev) prev.next = this;
+}
+
+// Increment in component units (i.e. the specified `n` gets multiplied by the #mult property),
+DateComponent.prototype.increment = function(d, n) {
+  if(n == null) n = 1;
+  if(this.mult !== 1) n *= this.mult;
+
+  this.set(d, this.get(d) + n);
+};
+
+DateComponent.prototype.get = function(d) {
+  return d.getMilliseconds();
+};
+
+DateComponent.prototype.set = function(d, v) {
+  d.setMilliseconds(v);
+};
+
+DateComponent.prototype.floorLocal = function(d, options) {
+  // noop for non-derived components.
+};
+
+DateComponent.prototype.floor = function(d, options) {
+  // Reset all components before (less significant than) this one.
+
+  // Only clear locally when a derived component (e.g. week, based on day, with mult 7).
+  var skip = 0;
+  if(this.mult !== 1) {
+    this.floorLocal(d, options);
+    // Skip the base value component (e.g. skip day).
+    skip = this.base;
+  }
+
+  var comp = this.prev;
+  while(comp) {
+    // Only clear base components.
+    if(comp.mult === 1 && comp.value !== skip) comp.clear(d, options);
+    comp = comp.prev;
+  }
+};
+
+DateComponent.prototype.floorMultiple = function(d, n, options) {
+  var first = this.first(d, options),
+      delta = this.get(d) - first; // base in units
+
+  if(delta) {
+    var M = n * this.mult,
+        offset = Math.floor(delta / M) * M; // offset in base units
+
+    this.set(d, first + offset);
+  }
+};
+
+DateComponent.prototype.clear = function(d, options) {
+  this.set(d, this.first(d, options));
+};
+
+// Chooses an appropriate multiple given a number of ticks.
+DateComponent.prototype.multiple = function(N, options) {
+  var ms = this.multiples,
+      ts = this.thresholds,
+      cl = this.closeds,
+      L  = ms.length,
+      i  = -1;
+
+  while(++i < L) if(cl[i] ? (N <= ts[i]) : (N < ts[i])) return ms[i];
+  throw new Error("Invalid configuration.");
+};
+
+DateComponent.prototype.resultAbove = function(mult) {
+  return this.castValue((this.value * mult) + 0.1, /*ceil*/true);
+};
+
+DateComponent.prototype.castValue = function(value, ceil) {
+  var ms = this.multiples;
+  if(!ms) return this._castValueResult(1, value, 1);
+
+  var m  = value / this.value,
+      L  = ms.length,
+      i;
+
+  if(ceil) {
+    i = -1;
+    while(++i < L) if(m <= ms[i]) return this._castValueResult(ms[i], value, 0);
+
+    // First of next precision component.
+    return this.next
+      ? this.next.castValue(value, ceil)
+      : this._castValueResult(ms[L - 1], value, 1);
+  }
+
+  i = L;
+  while(i--) if(ms[i] <= m) return this._castValueResult(ms[i], value, 0);
+
+  // Last of prev precision component.
+  return this.prev
+    ? this.prev.castValue(value, ceil)
+    : this._castValueResult(ms[0], value, -1);
+};
+
+DateComponent.prototype._castValueResult = function(mult, value, overflow) {
+  return {
+    comp:     this,
+    mult:     mult,
+    value:    this.value * mult,
+    source:   value,
+    overflow: overflow
+  };
+};
+
+DateComponent.prototype.withPrecision = function(value) {
+  var comp = this;
+  if(this.value !== value) {
+    // Custom precision, that reuses this one's format.
+    // Base unit is millisecond.
+    comp = new DateComponent(value, null, {
+      mult:   value,
+      format: this.format
+    });
+  }
+  return comp;
+};
+
+DateComponent.prototype.ticks = function(min, max, mult, options) {
+  var ticks = [],
+      tick  = new Date(min);
+
+  // TODO: need both?
+  // -- Floor start date (floor, independently of roundInside).
+  this.floor(tick, options);
+  // Floor the start date to the chosen multiple's first date.
+  if(mult > 1) this.floorMultiple(tick, mult, options);
+
+  // -- Generate ticks
+  if(pv.get(options, 'roundInside', 1)) {
+    // Accept a start tick coincident with the data min value.
+    // Increment, the start tick, otherwise.
+    if(min !== +tick) this.increment(tick, mult);
+
+    // At least one tick.
+    do {
+      ticks.push(new Date(tick));
+      this.increment(tick, mult);
+
+      // Accept an end tick coincident with the data max value.
+    } while(tick <= max);
+  } else {
+
+    ticks.push(new Date(tick));
+    do {
+      this.increment(tick, mult);
+      ticks.push(new Date(tick));
+    } while(tick < max);
+  }
+
+  return ticks;
+};
+
+// -----------
+// Date Utils
+
+function parseTickDateFormat(format) {
+  return format == null               ? null   :
+         typeof format === 'function' ? format :
+         pv.Format.date(format);
+}
+
+function firstWeekStartOfMonth(date, dateTickWeekStart) {
+  var d = new Date(date.getFullYear(), date.getMonth(), 1),
+      wd = dateTickWeekStart - d.getDay();
+
+  if(wd) {
+    if(wd < 0) wd += 7;
+    d.setDate(d.getDate() + wd);
+  }
+
+  return d;
+}
+
+function parseDatePrecision(value, dv) {
+  if(typeof value === 'string') {
+    var n = +value;
+    if(!isNaN(n)) {
+      value = n;
+    } else if(value) {
+      var m = /^(\d*)([a-zA-Z]+)$/.exec(value);
+      if(m) {
+        value = parseDateInterval(m[2]);
+        if(value) value *= (+m[1]) || 1;
+      }
+    }
+  }
+
+  if(typeof value !== 'number' || value < 0)
+    value = dv != null ? dv : 0;
+
+  return value;
+}
+
+function parseDateInterval(s) {
+  switch(s) {
+    case 'y':  return 31536e6;
+    case 'm':  return 2592e6;
+    case 'w':  return 6048e5;
+    case 'd':  return 864e5;
+    case 'h':  return 36e5;
+    case 'M':  return 6e4;
+    case 's':  return 1e3;
+    case 'ms': return 1;
+  }
+}
+
+// -----------
+// Date Registration, lookup
+
+var _dateComps = [];
+
+function defDateComp(value, keyArgs) {
+  var prev = highestPrecisionValueDateComp();
+
+  _dateComps.push(new DateComponent(value, prev, keyArgs));
+}
+
+function lowestPrecisionValueDateComp() {
+  return _dateComps[0];
+}
+
+function highestPrecisionValueDateComp() {
+  return _dateComps.length ? _dateComps[_dateComps.length - 1] : null;
+}
+
+// Obtains the greatest tick component less than or equal to length * N.
+function getGreatestLessOrEqualDateComp(length, N) {
+  if(N == null) N = 1;
+  var prev = highestPrecisionValueDateComp(),
+      comp;
+  do {
+    comp = prev;
+  } while((length < N * comp.value) && (prev = comp.prev));
+
+  return comp;
+}
+
+// -----------
+
+// Definition order must be in ascending value/duration order.
+
+// millisecond
+defDateComp(1, {
+  format: "%S.%Qs",
+  multiples:  [ 1,  5,  25,  50,  100,      250],
+  thresholds: [10, 50, 100, 200, 1000, Infinity],
+  closeds:    [ 1,  1,   1,   1,    1,        1]
+  //           <=  <=   <=  ...
+});
+
+// second
+defDateComp(1e3, {
+  get:    function(d) { return d.getSeconds(); },
+  set:    function(d, v) { d.setSeconds(v); },
+  format: "%I:%M:%S",
+  multiples:  [ 1,  5, 10, 15],
+  thresholds: [10, 60, 90, Infinity],
+  closeds:    [ 1,  1,  1, 1]
+});
+
+// minute
+defDateComp(6e4, {
+  get:    function(d) { return d.getMinutes(); },
+  set:    function(d, v) { d.setMinutes(v); },
+  format: "%I:%M %p",
+  multiples:  [ 1,  5, 10, 15],
+  thresholds: [10, 15, 30, Infinity],
+  closeds:    [ 1,  1,  1, 1]
+});
+
+// hour
+defDateComp(36e5, {
+  get:    function(d) { return d.getHours(); },
+  set:    function(d, v) { d.setHours(v); },
+  format: "%I:%M %p",
+  multiples:  [ 1,  3, 6],
+  thresholds: [10, 20, Infinity],
+  closeds:    [ 1,  1, 1]
+});
+
+// day
+defDateComp(864e5, {
+  get:    function(d) { return d.getDate(); },
+  set:    function(d, v) { d.setDate(v);    },
+  format: "%m/%d",
+  first:  1,
+  multiples:  [ 1,  2,  3, 5],
+  thresholds: [10, 15, 30, Infinity],
+  closeds:    [ 1,  0,  0, 1]
+});
+
+// // TODO: with nn = 5, a 2 days span ends up being shown as 48 hour ticks (except some are skipped)
+
+// week/7d   what is this? week of year? starting on?
+defDateComp(6048e5, {
+  get:    function(d) { return d.getDate(); },
+  set:    function(d, v) { d.setDate(v);    },
+  mult:   7,
+  // floors day to previous week start.
+  floor:  function(d, options) { // floorLocal
+    var wd = d.getDay() - pv.get(options, 'weekStart', 0);
+    if(wd !== 0) {
+      if(wd < 0) wd += 7;
+
+      this.set(d, this.get(d) - wd);
+    }
+  },
+  first:  function(d, options) {
+    return this.get(firstWeekStartOfMonth(d, pv.get(options, 'weekStart', 0)));
+  },
+  format: "%m/%d",
+  multiples:  [ 1,  2, 3],
+  thresholds: [10, 15, Infinity],
+  closeds:    [ 1,  1, 1]
+});
+
+// month/30d
+defDateComp(2592e6, {
+  get:    function(d) { return d.getMonth(); },
+  set:    function(d, v) { d.setMonth(v);    },
+  format: "%m/%Y",
+  multiples:  [ 1,  2, 3],
+  thresholds: [12, 24, Infinity],
+  closeds:    [ 1,  1, 1]
+});
+
+// year
+defDateComp(31536e6, {
+  get:    function(d) { return d.getFullYear(); },
+  set:    function(d, v) { d.setFullYear(v);    },
+  format: "%Y",
+  // Multiples
+  // 1, 2, 5, 10, 20, 50, 100, 200, 500, ...
+  multiple: function(N) {
+    if(N <= 10) return 1;
+    var mult = pv.logCeil(N / 15, 10);
+    if(N / mult < 2) mult /= 5;
+    else if(N / mult < 5) mult /= 2;
+    return mult;
+  },
+  castValue: function(value, ceil) {
+    // ex: M = 205; mult = 2.05; base = 100
+    // M = mult * base;
+    var M = value / this.value,
+        base, mult;
+    if(M < 1) {
+      if(!ceil)
+        // Go to previous precision, if any.
+        return this.prev
+          ? this.prev.castValue(value, ceil)
+          : this._castValueResult(1, value, /*overflow*/-1);
+
+      base = 1;
+    } else {
+      base = pv.logFloor(M, 10); // 1, 10, 100...
+    }
+
+    mult = M / base;
+
+    if(ceil) {
+      if(mult > 5) {
+        base *= 10;
+        mult = 1;
+      } else if(mult > 2) {
+        mult = 5;
+      } else if(mult > 1) {
+        mult = 2;
+      } else {
+        mult = 1;
+      }
+    } else {
+      if(mult > 5) {
+        mult = 5;
+      } else if(mult > 2) {
+        mult = 2;
+      } else if(mult > 1) {
+        mult = 1;
+      } else if(mult < 1) {
+        // Go to previous precision, if any.
+        return this.prev
+          ? this.prev.castValue(value, ceil)
+          : this._castValueResult(base, value, /*overflow*/-1);
+      }
+    }
+
+    return this._castValueResult(base * mult, value, 0);
+  }
+});
+
 /**
  * Returns a linear scale for the specified domain. The arguments to this
  * constructor are optional, and equivalent to calling {@link #domain}.


### PR DESCRIPTION
- Protovis update.
- Cartesian continuous axis
  - New options TickUnit, TickUnitMin and TickUnitMax.
  - Temporal axis now also support LabelSpacingMin.
  - Handling edge cases of 1,2,3 tick counts.
  - Option DesiredTickCount now supports value Infinity, meaning: use as many ticks as can fit without overlapping (this is the default for numeric ticks).
  - Options DesiredTickCount and LabelSpacingMin are now both used; Previously, when DesiredTickCount was specified, LabelSpacingMin was ignored.
  - Slight relaxing of the label trimming decision
  - Slightly increased the effective textHeight value used for measure calculations; was affecting adversely the minimum label spacings decisions. Unfortunately, this causes old labelSpacingMin values to result differently.
  - Fine tuning labelSpacingMin's default value, for better backward compatibility
  - Fixed some "minimum label spacings" calculations.
- Fixed issue in SVG generation, with NaNs; occurred in the grid rules, when the main plot panel would not be visible, due to there being no space available.

@pamval please review.
