### PR TITLE
[CDF-405] -  CCC - Options to control the minimum and maximum precision/units of temporal ticks

### DIFF
--- a/doc/model/axes/axis-cartesian-continuous.xml
+++ b/doc/model/axes/axis-cartesian-continuous.xml
@@ -99,30 +99,46 @@
                     <b>The minimum tick count</b>
                 </p>
 
-                For tick counts greater than two or three, the algorithm strives to satisfy the user's desire!
+                This actually depends on the value of <c:link to="#domainRoundMode" />.
+                <ul>
+                    <li>
+                        <p><b><i>domainRoundMode</i> is <c:link to="pvc.options.varia.AxisDomainRoundingMode#Tick" /></b></p>
 
-                However,
-                the algorithm always generates at least two or three ticks,
-                effectively ignoring both <i>desiredTickCount</i> and <i>labelSpacingMin</i>.
+                        For tick counts greater than two or three, the algorithm strives to satisfy the user's desire!
 
-                At least three ticks are generated for numeric domains having both negative and positive data.
-                There are also temporal domain cases where a minimum of three ticks are generated.
+                        However,
+                        the algorithm always generates at least two or three ticks,
+                        ignoring both <i>desiredTickCount</i> and <i>labelSpacingMin</i>,
+                        if needed.
 
-                When the labels of these ticks really overlap,
-                one of the labels is kept visible and the other(s) is hidden.
+                        At least three ticks are generated for numeric domains having both negative and positive data.
+                        There are also temporal domain cases where a minimum of three ticks are generated.
 
-                This behavior ensures that, unless it is really impossible to do so,
-                the axis serves one of its main purposes - allowing to translate visual lengths.
+                        When the labels of these ticks really overlap,
+                        one of the labels is kept visible and the other(s) is hidden.
 
-                When three tick labels overlap,
-                the middle label is kept visible and the end labels are hidden.
+                        This behavior ensures that, unless it is really impossible to do so,
+                        the axis serves one of its main purposes - allowing to translate visual lengths.
 
-                When two tick labels overlap,
-                one of the labels
-                — the one with tick value <tt>0</tt>, if any, or the first one, if none —
-                is kept visible and the other is hidden.
+                        When three tick labels overlap,
+                        the middle label is kept visible and the end labels are hidden.
 
-                Specifying a value of <tt>1</tt> ensures the minimum tick count is used.
+                        When two tick labels overlap,
+                        one of the labels
+                        — the one with tick value <tt>0</tt>, if any, or the first one, if none —
+                        is kept visible and the other is hidden.
+                    </li>
+                    <li>
+                        <p><b><i>domainRoundMode</i> is
+                            <c:link to="pvc.options.varia.AxisDomainRoundingMode#None" /> or
+                            <c:link to="pvc.options.varia.AxisDomainRoundingMode#Nice" /></b></p>
+
+                        The algorithm always generates at least one tick.
+                    </li>
+                </ul>
+
+
+                Specifying a value of <tt>1</tt> results in the minimum possible tick count.
 
                 <p>
                     <b>Domain type specifics</b>
@@ -215,6 +231,7 @@
                 See related axis options:
                 <c:link to="#tickUnitMin" />,
                 <c:link to="#tickUnitMax" />,
+                <c:link to="#domainRoundMode" />,
                 <c:link to="#desiredTickCount" /> and
                 <c:link to="pvc.options.axes.AnyNonHierarchicalCartesianAxis#labelSpacingMin" />.
 

--- a/package-res/ccc/core/cartesian/axis/abstract-cart-axis-panel.js
+++ b/package-res/ccc/core/cartesian/axis/abstract-cart-axis-panel.js
@@ -525,20 +525,22 @@ def
         // Hide 2/3 ticks only if they actually overlap (spacing = 0).
         // Keep at least two ticks until they overlap.
         var L = layoutInfo.ticks.length;
-        if(L > tickCountMax &&
-           tickCountMax <= 2 &&
-           L <= 3 &&
-           ((L-1) * bandSizeMin > clientLength)) {
+        if(this.axis.option('DomainRoundMode') === 'tick') {
+            if(L > tickCountMax &&
+               tickCountMax <= 2 &&
+               L <= 3 &&
+               ((L-1) * bandSizeMin > clientLength)) {
 
-            // Minimum 3 ticks. When number, usually 0 at center. Hide end ticks.
-            if(L === 3) {
-                layoutInfo.ticksText[0] = '';
-                layoutInfo.ticksText[2] = '';
-                layoutInfo.maxTextWidth = null;
-            } else if(L === 2) {
-                // Minimum 2 ticks. Maybe 0 in one end. Hide non-zero tick, preferably.
-                layoutInfo.ticksText[(!domain[1]) ? 0 : 1] = '';
-                layoutInfo.maxTextWidth = null;
+                // Minimum 3 ticks. When number, usually 0 at center. Hide end ticks.
+                if(L === 3) {
+                    layoutInfo.ticksText[0] = '';
+                    layoutInfo.ticksText[2] = '';
+                    layoutInfo.maxTextWidth = null;
+                } else if(L === 2) {
+                    // Minimum 2 ticks. Maybe 0 in one end. Hide non-zero tick, preferably.
+                    layoutInfo.ticksText[(!domain[1]) ? 0 : 1] = '';
+                    layoutInfo.maxTextWidth = null;
+                }
             }
         }
 
@@ -613,7 +615,7 @@ def
                 return pv.Text.measureWidth(text, this.font);
             }, this);
 
-            return Math.max((domainTextLength[1] + domainTextLength[0]) / 2, li.textHeight);
+            return Math.max(domainTextLength[0], domainTextLength[1], li.textHeight);
         }
 
         // Vertical


### PR DESCRIPTION
- Fix case, for DomainRoundMode != tick, where step would be greater than the span, resulting in 0 ticks being generated. An NPE error was thrown in CCC.
- Fix JsDocs

@pamval please review
