### PR TITLE
[CDF-414] - CCC - spinoff code of the "pvc.data" namespace into a new namespace: CDO

### DIFF
--- a/package-res/def/prologue.js
+++ b/package-res/def/prologue.js
@@ -8,7 +8,12 @@ var A_slice  = Array.prototype.slice,
         if(defProp) try { defProp({}, 'test', {}); } catch(ex) { return null; }
         return defProp;
     }()),
-    O_getOwnPropDesc = O_defProp && Object.getOwnPropertyDescriptor,
+    O_getOwnPropDesc = (function() {
+        var ownPropDesc = O_defProp && Object.getOwnPropertyDescriptor;
+        // Rhino returns value === undefined!
+        if(ownPropDesc && ownPropDesc({value: null}, 'value').value === null)
+            return ownPropDesc;
+    }()),
     F_protoOrSelf = function(F) { return F.prototype || F; };
 
 
@@ -24,7 +29,7 @@ var A_slice  = Array.prototype.slice,
  */
 
 /**
- * TODO: Docuemnt this
+ * TODO: Document this
  * @param {String|def.QualifiedName|object|array} [name] The qualified name to define,
  *  as a string or a qualified name instance.
  *


### PR DESCRIPTION
- Fix - don't use Object.getOwnPropertyDescriptor in Rhino, it's buggy.

@pamval please review.
