### PR TITLE
[CLEANUP] - Maintenance script for copying kettle generated CDE definitions to the CDE folder besides that of CCC.

### DIFF
--- a/distToCDE.sh
+++ b/distToCDE.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cp -Rf doc/kettle/output/* ../cde/cde-core/resource/resources/base/;


### PR DESCRIPTION
@pamval please review.