### PR TITLE
[CDF-443] - CCC - Sunburst - Misbehavior of colorRole and colorMode

### DIFF
--- a/doc/model/charts/basic.xml
+++ b/doc/model/charts/basic.xml
@@ -703,6 +703,20 @@
             </c:documentation>
         </c:property>
 
+        <c:property name="dataTypeCheckingMode"
+                    type="pvc.options.varia.DataTypeCheckingMode" excludeIn="cde" category="Chart > Data Source">
+            <c:documentation>
+                The confirmation mode of the column types declared in a dataset's metadata.
+
+                The default value depends on the chart type.
+                The <i>bullet</i> chart type has a default of <c:link to="pvc.options.varia.DataTypeCheckingMode#Extended" />.
+                All other chart types have a default of <c:link to="pvc.options.varia.DataTypeCheckingMode#Minimum" />.
+
+                Data type checking can be disabled by specifying the
+                value <c:link to="pvc.options.varia.DataTypeCheckingMode#None" />.
+            </c:documentation>
+        </c:property>
+
         <c:property name="readers" type="string list(pvc.options.DimensionsReader)" category="Chart > Data Source">
             <c:documentation>
                 A list of dimension names to load from corresponding <i>logical table</i> columns.

--- a/doc/model/charts/box.xml
+++ b/doc/model/charts/box.xml
@@ -50,7 +50,7 @@
             }
             </style>
 
-            All the following, are possible <i>default layouts</i> and dimension assignments:
+            All the following are possible <i>default layouts</i> and dimension assignments:
 
             <table class="dataformat">
                 <tr><td><b>Index</b></td><td>0</td><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td></tr>

--- a/doc/model/charts/bullet.xml
+++ b/doc/model/charts/bullet.xml
@@ -18,7 +18,12 @@
             For general information on the supported <b>data formats</b>
             see <c:link to="pvc.options.charts.BasicChart" />.
 
-            The bullet chart employs a non-default <i>logical row</i> to dimensions mapping:
+            Note that, unlike most chart types,
+            the bullet chart has a default
+            <c:link to="#dataTypeCheckingMode" />
+            of <c:link to="pvc.options.varia.DataTypeCheckingMode#Extended" />.
+
+            Also, the bullet chart employs a non-default <i>logical row</i> to dimensions mapping:
             <ol>
                 <li>The first free <i>discrete</i> column of the <i>logical table</i>
                     generates and loads the "title" dimension, if free.
@@ -40,7 +45,7 @@
                 </li>
             </ol>
 
-            All the following, are possible <i>default layouts</i> and dimension assignments:
+            All the following are possible <i>default layouts</i> and dimension assignments:
             <style>
             .dataformat {
                 border-spacing: 0;
@@ -49,7 +54,7 @@
             .dataformat td {
                 border:  solid 1px;
                 padding: 3px;
-                width:   80px;
+                width:   70px;
             }
             </style>
             <table class="dataformat">

--- a/doc/model/charts/point-metric.xml
+++ b/doc/model/charts/point-metric.xml
@@ -50,7 +50,7 @@
             }
             </style>
 
-            All the following, are possible <i>default layouts</i> and dimension assignments:
+            All the following are possible <i>default layouts</i> and dimension assignments:
 
             <table class="dataformat">
                 <tr><td><b>Index</b></td><td>0</td><td>1</td><td>2</td></tr>

--- a/doc/model/varia/_varia.xml
+++ b/doc/model/varia/_varia.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<c:model 
-    xmlns:c="urn:webdetails/com/2012" 
+<c:model
+    xmlns:c="urn:webdetails/com/2012"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="urn:webdetails/com/2012 ../../schema/com_2012.xsd"
     xmlns="http://www.w3.org/1999/xhtml">
-    
+
     <c:space name="pvc.options.varia">
         <c:documentation>
-            The namespace of various options-related helper types. 
+            The namespace of various options-related helper types.
         </c:documentation>
     </c:space>
-    
+
     <!-- ATOMS -->
     <c:include the="varia/atoms/chartClearSelectionMode.xml" />
     <c:include the="varia/atoms/chartOrientation.xml" />
@@ -45,7 +45,8 @@
     <c:include the="varia/atoms/pointingCollapse.xml" />
     <c:include the="varia/atoms/sliceOrder.xml" />
     <c:include the="varia/atoms/sunburstColorMode.xml" />
-        
+    <c:include the="varia/atoms/dataTypeCheckingMode.xml" />
+
     <!-- FUNCTIONS -->
     <c:include the="varia/functions/colorTransform.xml" />
     <c:include the="varia/functions/dimensionComparer.xml" />
@@ -61,7 +62,7 @@
     <c:include the="varia/functions/userSelectionAction.xml" />
     <c:include the="varia/functions/axisTickFormatter.xml" />
     <c:include the="varia/functions/dataWhere.xml" />
-    
+
     <!-- COMPLEX TYPES - AUXILIAR -->
     <c:include the="varia/sides.xml" />
     <c:include the="varia/size.xml" />

--- a/doc/model/varia/atoms/dataTypeCheckingMode.xml
+++ b/doc/model/varia/atoms/dataTypeCheckingMode.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<c:model
+    xmlns:c="urn:webdetails/com/2012"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:webdetails/com/2012 ../../../schema/com_2012.xsd"
+    xmlns="http://www.w3.org/1999/xhtml">
+
+    <c:atomType name="DataTypeCheckingMode" space="pvc.options.varia" base="string">
+        <c:documentation>
+            The confirmation mode of the column types declared in a dataset's metadata.
+
+            The column type metadata is sometimes incorrect
+            due to the existence of nulls in the first row and
+            the inability of some data sources to
+            properly identify the data type in that case.
+
+            Other times, its incorrect just because...
+            "Numeric" columns may be declared as "String",
+            and contain either numbers or numeric strings.
+        </c:documentation>
+
+        <c:atom name="None" value="'none'">
+            <c:documentation>
+                Trusts the data source column type metadata.
+            </c:documentation>
+        </c:atom>
+
+        <c:atom name="Minimum" value="'minimum'">
+            <c:documentation>
+                Checks if columns declared as "String" are "Numeric",
+                based on the type of first non-null value.
+
+                The column type is established by the
+                first row in which the column value is non-null.
+                The type will be considered "Numeric" if the
+                value is a JavaScript number.
+            </c:documentation>
+        </c:atom>
+
+        <c:atom name="Extended" value="'extended'">
+            <c:documentation>
+                Checks if columns declared as "String" are "Numeric",
+                based on the type and form of the first non-null value.
+
+                The column type is established by the
+                first row in which the column value is non-null.
+                The type will be considered "Numeric" if the
+                value is a JavaScript number <i>or</i>
+                if it can be parsed as a number.
+            </c:documentation>
+        </c:atom>
+    </c:atomType>
+</c:model>

--- a/package-res/ccc/core/base/chart/chart.data.js
+++ b/package-res/ccc/core/base/chart/chart.data.js
@@ -309,6 +309,7 @@ pvc.BaseChart
             measuresIndexes:   options.measuresIndexes, // relational multi-valued
             multiChartIndexes: options.multiChartIndexes,
             ignoreMetadataLabels: dataOptions.ignoreMetadataLabels,
+            typeCheckingMode:  pvc.parseDataTypeCheckingMode(dataOptions.typeCheckingMode),
 
             // crosstab
             separator:         dataOptions.separator,

--- a/package-res/ccc/core/base/chart/chart.js
+++ b/package-res/ccc/core/base/chart/chart.js
@@ -528,6 +528,7 @@ def
         processDataOption('dataCategoriesCount',      'categoriesCount');
         processDataOption('dataIgnoreMetadataLabels', 'ignoreMetadataLabels');
         processDataOption('dataWhere',                'where');
+        processDataOption('dataTypeCheckingMode',     'typeCheckingMode');
 
         var plot2 = options.plot2,
             plot2Series, plot2SeriesIndexes;

--- a/package-res/ccc/core/base/value/enums.js
+++ b/package-res/ccc/core/base/value/enums.js
@@ -26,6 +26,9 @@ pvc.parsePointingCollapse =
 // ['square', 'circle', 'diamond', 'triangle', 'cross', 'bar']
 pvc.parseShape = pvc.makeEnumParser('shape', pv.Scene.hasSymbol, null);
 
+pvc.parseDataTypeCheckingMode =
+    pvc.makeEnumParser('typeCheckingMode', ['none', 'minimum', 'extended'], 'minimum');
+
 pvc.parseContinuousColorScaleType = function(scaleType) {
     if(scaleType) {
         scaleType = (''+scaleType).toLowerCase();

--- a/package-res/ccc/plugin/bullet/bullet-chart.js
+++ b/package-res/ccc/plugin/bullet/bullet-chart.js
@@ -65,7 +65,8 @@ def
         },
 
         crosstabMode: false,
-        seriesInRows: false
+        seriesInRows: false,
+        dataTypeCheckingMode: 'advanced' // force numeric strings recognition
     }
 });
 


### PR DESCRIPTION
Fixes regression on Bullet chart column type ignorance, by introduction of a new chart option `dataTypeCheckingMode` that allows extending the usually made confirmation of column types to cases where the numbers are given as numeric strings. 

The bullet chart has a default value, `"extended"` that maintains compatibility with the old behavior most of the times.
The `"none"` value can be used to disable type guessing altogether, for cases where the `"extended"` heuristic may have unwanted consequences (like string columns that really have numeric data and should, still, be considered as string columns - in the bullet chart, numeric-valued "title" or "subTitle" seem to be improbable use cases).

All other chart types maintain the old behavior, by having the default `dataTypeCheckingMode`  of `"minimum"`.

@pamval please review.