### PR TITLE
[ANALYZER-3004] - Memory Leak when working with analysis report

### DIFF
--- a/package-res/ccc/core/base/chart/chart.js
+++ b/package-res/ccc/core/base/chart/chart.js
@@ -227,9 +227,6 @@ def
         if(isRootInit) {
             this._processDataOptions(this.options);
 
-            // Now's a good time as any other to clear out all tipsy tooltips
-            pvc.removeTipsyLegends();
-
             // Any data exists or throws
             // (must be done AFTER processing options
             //  because of width, height properties and noData extension point...)
@@ -607,11 +604,12 @@ def
         try {
             this.useTextMeasureCache(function() {
                 try {
-                    while(true) {
+                    while(true) { 
+                        if(!this.parent && this.isCreated)
+                            pvc.removeTipsyLegends();
+                        
                         if(!this.isCreated || recreate)
                             this._create({reloadData: reloadData});
-                        else if(!this.parent && this.isCreated)
-                            pvc.removeTipsyLegends();
 
                         // TODO: Currently, the following always redirects the call
                         // to topRoot.render;


### PR DESCRIPTION
* Protovis fix.
* Fixed tipsy leaking `Tipsy` instances that, would, in turn, leak referenced chart objects. Each re-render caused by clicking the legend would leak one Tipsy instance.
   The "fakeTipsyTarget" div, created by each tipsy instance, would leak, held by jQuery's cache, due to an attached event, and the element no being removed by jQuery or the event explicitly detached.

Depends on webdetails/protovis#22.

@pamval please review.