### PR TITLE
[BACKLOG-3325] PAZ: When drilling a chart the tool tip does not disap…

### DIFF
--- a/package-res/ccc/core/base/chart/chart.js
+++ b/package-res/ccc/core/base/chart/chart.js
@@ -605,7 +605,7 @@ def
             this.useTextMeasureCache(function() {
                 try {
                     while(true) { 
-                        if(!this.parent && this.isCreated)
+                        if(!this.parent)
                             pvc.removeTipsyLegends();
                         
                         if(!this.isCreated || recreate)


### PR DESCRIPTION
…pear
@dcleao When you fixed memory leak problem (ANALYZER-3004) is occurred new issue with tool tip.
My fix solves this problem. Could you review it?