### PR TITLE
[CDF-563] - CCC - Cartesian Axis - Do not show "value" tooltip unless…

### DIFF
--- a/package-res/ccc/core/cartesian/axis/abstract-cart-axis-panel.js
+++ b/package-res/ccc/core/cartesian/axis/abstract-cart-axis-panel.js
@@ -1133,7 +1133,15 @@ def
 
             if(autoContent === 'value') {
                 tipOptions.isLazy = false;
-                return function(context) { return context.scene.vars.tick.label; };
+                // Show the label if:
+                // 1. the angle is not 0
+                // 2. it has been trimmed or grouped with several
+                return function(context) {
+                    var pvMark = context.pvMark,
+                        label  = context.scene.vars.tick.label;
+
+                    return pvMark.textAngle() || (pvMark.text() !== label) ? label : "";
+                };
             }
         }
     },


### PR DESCRIPTION
… really needed

* only show the cartesian axes' "value" tooltip if the label has a non-zero textAngle or the text has been trimmed or it is of a grouped labels scene.

@pamval please review.