### PR TITLE
[CDF-559] - CCC - Grouped Area Chart - Area transparency effect does …

### DIFF
--- a/doc/model/charts/point.xml
+++ b/doc/model/charts/point.xml
@@ -114,6 +114,17 @@
             </c:documentation>
         </c:property>
 
+        <c:property name="areasFillOpacity" type="number" default="0.5" category="Style">
+            <c:documentation>
+                A value that is multiplied by the opacity value of the area's base color.
+
+                A non-negative number, possibly <tt>Infinity</tt>.
+
+                This option is ignored unless <c:link to="#areasVisible" /> is <tt>true</tt>
+                and the plot is <i>not</i> stacked.
+            </c:documentation>
+        </c:property>
+
         <c:property name="extensionPoints" type="pvc.options.ext.PointPlotExtensionPoints" category="Style" expandUse="optional">
             <c:documentation>
                 The extension points object contains style definitions for

--- a/package-res/ccc/plugin/point/point-plot.js
+++ b/package-res/ccc/plugin/point/point-plot.js
@@ -4,7 +4,7 @@
 
 /**
  * Initializes a point plot.
- * 
+ *
  * @name pvc.visual.PointPlot
  * @class Represents a Point plot.
  * @extends pvc.visual.CategoricalPlot
@@ -49,6 +49,12 @@ def('pvc.visual.PointPlot', pvc.visual.CategoricalPlot.extend({
             data:    pvcPoint_buildVisibleOption('Areas', false),
             cast:    Boolean,
             value:   false
+        },
+
+        AreasFillOpacity: {
+            resolve: '_resolveFull',
+            cast:    def.number.toNonNegative,
+            value:   null
         },
 
         ValuesAnchor: { // override


### PR DESCRIPTION
…not respect the color scale opacity

* new option "AreasFillOpacity" allows to easily control the opacity of non-stacked areas; also, the applied opacity now respects the opacity in the default/extended color, by multiplying by, instead of replacing.

@pamval please review.