### PR TITLE
[ANALYZER-3058] - Backport of ANALYZER-3058 - Memory leaks during mul…

### DIFF
--- a/package-res/ccc/core/base/chart/chart.js
+++ b/package-res/ccc/core/base/chart/chart.js
@@ -8,7 +8,7 @@ def
 .add(pvc.visual.Interactive)
 .init(function(options) {
     var originalOptions = options;
-    
+
     var parent = this.parent = def.get(options, 'parent') || null;
     if(parent) {
         /*jshint expr:true */
@@ -603,10 +603,10 @@ def
         try {
             this.useTextMeasureCache(function() {
                 try {
-                    while(true) { 
-                        if(!this.parent && this.isCreated)
+                    while(true) {
+                        if(!this.parent)
                             pvc.removeTipsyLegends();
-                        
+
                         if(!this.isCreated || recreate)
                             this._create({reloadData: reloadData});
 
@@ -713,6 +713,14 @@ def
             // TODO: implement chart dispose
 
             this._disposed = true;
+
+            var pvRootPanel = this.basePanel && this.basePanel.pvRootPanel,
+                tipsy = pv.Behavior.tipsy;
+
+            if(tipsy && tipsy.disposeAll)
+                tipsy.disposeAll(pvRootPanel);
+
+            if(pvRootPanel) pvRootPanel.dispose();
         }
     },
 

--- a/package-res/ccc/core/base/prologue.js
+++ b/package-res/ccc/core/base/prologue.js
@@ -61,11 +61,9 @@ pvc.orientation = {
 
 // TODO: change the name of this
 pvc.removeTipsyLegends = function() {
-    try {
-        $('.tipsy').remove();
-    } catch(e) {
-        // Do nothing
-    }
+    var tipsy = pv.Behavior.tipsy;
+    if(tipsy && tipsy.removeAll)
+        tipsy.removeAll();
 };
 
 pvc.createDateComparer = function(parser, key) {

--- a/package-res/lib/protovis.js
+++ b/package-res/lib/protovis.js
@@ -11,7 +11,7 @@
  * the license for the specific language governing your rights and limitations.
  */
  /*! Copyright 2010 Stanford Visualization Group, Mike Bostock, BSD license. */
- /*! 0a846e02116638f4d7f3c88a223ee1ae23f0cb3f */
+ /*! 10fd5c729c201633f0967565b7cc78a0d507bab7 */
 /**
  * @class The built-in Array class.
  * @name Array
@@ -15213,6 +15213,25 @@ pv.Panel.prototype._registerBoundEvent = function(source, name, listener, captur
   if(source.removeEventListener) {
     var boundEvents = this._boundEvents || (this._boundEvents = []);
     boundEvents.push([source, name, listener, capturePhase]);
+  }
+};
+
+pv.Panel.prototype.dispose = function() {
+  var root = this.root;
+
+  root._disposeRootPanel();
+
+  var canvas = root.canvas();
+  root.canvas(null);
+
+  canvas.$panel = null;
+  root.binds = null;
+
+  var scene = root.scene;
+  if(scene) {
+      scene.$defs = null;
+      scene.$g    = null;
+      root.scene  = null;
   }
 };
 

--- a/package-res/lib/tipsy.js
+++ b/package-res/lib/tipsy.js
@@ -337,7 +337,7 @@
             updateTipDebug();
             
             // Create the tipsy instance
-            $fakeTipTarget.data('tipsy', null); // Otherwise a new tipsy is not created, if there's one there already.
+            $fakeTipTarget.removeData('tipsy'); // Otherwise a new tipsy is not created, if there's one there already.
 
             var opts2 = Object.create(opts);
             // Gravity is intercepted to allow for off screen bounds reaction.
@@ -556,7 +556,7 @@
             if(_tip.debug >= 20) _tip.log("[TIPSY] #" + _tipsyId + " Disposing");
             hideTipsyOther();
             if($fakeTipTarget) {
-                $fakeTipTarget.data("tipsy", null);
+                $fakeTipTarget.removeData("tipsy");
                 $fakeTipTarget.each(function(elem) { elem.$tooltipOptions = null; });
                 $fakeTipTarget.remove();
                 $fakeTipTarget = null;
@@ -590,7 +590,7 @@
             if(hideTipsies && hideTipsies.length > 1) {
                 if(_tip.debug >= 20) _tip.group("[TIPSY] #" + _tipsyId + " Hiding Others");
                 hideTipsies.forEach(function(hideTipsyFun) {
-                    if(hideTipsyFun !== hideTipsyOther) hideTipsyFun();
+                    if(hideTipsyFun !== disposeTipsy) hideTipsyFun();
                 });
                 if(_tip.debug >= 20) _tip.groupEnd();
             }
@@ -808,7 +808,30 @@
         if(typeof console !== "undefined") console.groupEnd();
     };
 
-    
+    _tip.disposeAll = function(panel) {
+        if(panel) {
+            var canvas = panel.root.canvas();
+            if(canvas) {
+                var $canvas = $(canvas),
+                    sharedTipsyInfo = $canvas.data("tipsy-pv-shared-info");
+                if(sharedTipsyInfo) {
+                    if(sharedTipsyInfo.behaviors)
+                        sharedTipsyInfo.behaviors.forEach(function(dispose) {
+                            dispose();
+                        });
+
+                    $canvas.removeData("tipsy-pv-shared-info");
+                }
+            }
+        }
+
+        _tip.removeAll();
+    };
+
+    _tip.removeAll = function() {
+        $('.tipsy').remove();
+    };
+
     function toParentTransform(parentPanel){
         return pv.Transform.identity.
                     translate(parentPanel.left(), parentPanel.top()).


### PR DESCRIPTION
…tiple changing of chart type

* Implemented a dispose method
  * Clears any tipsies (or leaks through jQuery handlers and attached data)
  * Disposes protovis root panel (events and main DOM references)

@dcleao, review it please. This is a backport of https://github.com/webdetails/ccc/pull/210 and it was done manually, since cherry-pick failed.
/cc @pamval 