### PR TITLE
[SP-1946] - Backport of ANALYZER-3058 - Memory leaks during multiple …

### DIFF
--- a/package-res/ccc/core/base/chart/chart.js
+++ b/package-res/ccc/core/base/chart/chart.js
@@ -604,10 +604,10 @@ def
         try {
             this.useTextMeasureCache(function() {
                 try {
-                    while(true) { 
+                    while(true) {
                         if(!this.parent)
                             pvc.removeTipsyLegends();
-                        
+
                         if(!this.isCreated || recreate)
                             this._create({reloadData: reloadData});
 
@@ -718,10 +718,15 @@ def
      */
     dispose: function() {
         if(!this._disposed) {
-
-            // TODO: implement chart dispose
-
             this._disposed = true;
+
+            var pvRootPanel = this.basePanel && this.basePanel.pvRootPanel,
+                tipsy = pv.Behavior.tipsy;
+
+            if(tipsy && tipsy.disposeAll)
+                tipsy.disposeAll(pvRootPanel);
+
+            if(pvRootPanel) pvRootPanel.dispose();
         }
     },
 

--- a/package-res/ccc/core/base/prologue.js
+++ b/package-res/ccc/core/base/prologue.js
@@ -71,11 +71,9 @@ pvc.orientation = {
 
 // TODO: change the name of this
 pvc.removeTipsyLegends = function() {
-    try {
-        $('.tipsy').remove();
-    } catch(e) {
-        // Do nothing
-    }
+    var tipsy = pv.Behavior.tipsy;
+    if(tipsy && tipsy.removeAll)
+        tipsy.removeAll();
 };
 
 pvc.createDateComparer = function(parser, key) {

--- a/package-res/lib/protovis.js
+++ b/package-res/lib/protovis.js
@@ -11,7 +11,7 @@
  * the license for the specific language governing your rights and limitations.
  */
  /*! Copyright 2010 Stanford Visualization Group, Mike Bostock, BSD license. */
- /*! 0a846e02116638f4d7f3c88a223ee1ae23f0cb3f */
+ /*! 10fd5c729c201633f0967565b7cc78a0d507bab7 */
 /**
  * @class The built-in Array class.
  * @name Array
@@ -14995,9 +14995,9 @@ pv.Panel.prototype.type = "panel";
 /**
  * Indicates that contained marks are only pointable
  * if the mouse is within the panel.
- * 
+ *
  * The default value is <tt>false</tt>.
- * 
+ *
  * @type boolean
  */
 pv.Panel.prototype.isPointingBarrier = false;
@@ -15051,7 +15051,7 @@ pv.Panel.prototype.add = function(Type) {
   child.root = this.root;
   child.childIndex = this.children.length;
   this.children.push(child);
-  
+
   // Process possibly set zOrder
   var zOrder = (+child._zOrder) || 0; // NaN -> 0
   if(zOrder !== 0) { this._zOrderChildCount++; }
@@ -15106,7 +15106,7 @@ pv.Panel.prototype.buildInstance = function(s) {
     child.scale = scale;
     child.build();
     // Leave scene in children, because these might me used
-    // during build of siblings; 
+    // during build of siblings;
     // calling a sibling mark's property method (instance() evaluates to same index).
   }
 
@@ -15157,7 +15157,7 @@ pv.Panel.prototype.buildInstance = function(s) {
 pv.Panel.prototype.buildImplied = function(s) {
   if(!this.parent && !this._buildRootInstanceImplied(s)) {
     // Canvas was stolen by other root panel.
-    // Set the root scene instance as invisible, 
+    // Set the root scene instance as invisible,
     //  to prevent rendering on the stolen canvas.
     s.visible = false;
     return;
@@ -15172,7 +15172,7 @@ pv.Panel.prototype._buildRootInstanceImplied = function(s) {
   // Was a canvas specified for *this* instance?
   var c = s.canvas;
   if(!c) {
-    // For every instance that doesn't specify a canvas, 
+    // For every instance that doesn't specify a canvas,
     //  a new canvas element (a span) is created for it.
     // This is a typical case of a viz having multiple canvas.
     s.canvas = this._rootInstanceGetInlineCanvas(s);
@@ -15191,9 +15191,9 @@ pv.Panel.prototype._rootInstanceStealCanvas = function(s, c) {
   //  and start stealing the canvas to one another...
   // TODO: There's no provision here to deal with the same canvas being used
   //  by different instances of the same root panel?
-  // If this is the first render of this root panel, 
+  // If this is the first render of this root panel,
   //  then we're allowed to steal it from another panel.
-  // If this is not our first render, 
+  // If this is not our first render,
   //  then just accept that the canvas has been stolen.
   var cPanel = c.$panel;
   if(cPanel !== this) {
@@ -15203,13 +15203,13 @@ pv.Panel.prototype._rootInstanceStealCanvas = function(s, c) {
         return false;
       }
 
-      // We win the fight, 
+      // We win the fight,
       // dispose the other root panel.
       cPanel._disposeRootPanel();
-      
-      this._updateCreateId(c);  
+
+      this._updateCreateId(c);
     }
-    
+
     c.$panel = this;
     pv.removeChildren(c);
   } else {
@@ -15226,13 +15226,32 @@ pv.Panel.prototype._registerBoundEvent = function(source, name, listener, captur
   }
 };
 
+pv.Panel.prototype.dispose = function() {
+  var root = this.root;
+
+  root._disposeRootPanel();
+
+  var canvas = root.canvas();
+  root.canvas(null);
+
+  canvas.$panel = null;
+  root.binds = null;
+
+  var scene = root.scene;
+  if(scene) {
+      scene.$defs = null;
+      scene.$g    = null;
+      root.scene  = null;
+  }
+};
+
 pv.Panel.prototype._disposeRootPanel = function() {
   // Clear running transitions.
   // If we don't do this,
   //  a running animation's setTimeouts will
-  //  continue rendering, over a canvas that 
+  //  continue rendering, over a canvas that
   //  might already b being used by other panel,
-  //  resulting in "concurrent" updates to 
+  //  resulting in "concurrent" updates to
   //  the same dom elements -- a big mess.
   var t = this.$transition;
   t && t.stop();
@@ -15267,14 +15286,14 @@ pv.Panel.prototype._rootInstanceInitCanvas = function(s, c) {
 };
 
 pv.Panel.prototype._rootInstanceGetInlineCanvas = function(s) {
-  // When no container is specified, 
+  // When no container is specified,
   //  the vis is added inline, as a span.
-  // The spans are created on first render only, 
+  // The spans are created on first render only,
   //  and cached for later renders.
-  // If the visualization was created using a 
+  // If the visualization was created using a
   //  script element with language "text/javascript+protovis",
   //  the span of each instance is added right before the script tag.
-  // Otherwise, the canvas is added as a sibling of 
+  // Otherwise, the canvas is added as a sibling of
   //  the last (leaf) element of the page.
   var cache = this.$canvas || (this.$canvas = []);
   var c;
@@ -15290,7 +15309,7 @@ pv.Panel.prototype._rootInstanceGetInlineCanvas = function(s) {
 
       // Take its parent.
       if(n != document.body) { n = n.parentNode; }
-      
+
       // Add canvas as last child.
       n.appendChild(c);
     }
@@ -15298,10 +15317,10 @@ pv.Panel.prototype._rootInstanceGetInlineCanvas = function(s) {
   return c;
 };
 
-/** 
+/**
  * Updates the protovis create counter in the specified canvas.
  * This allows external entities to detect that a previous
- * panel attached to this canvas has been disposed of, 
+ * panel attached to this canvas has been disposed of,
  * or is no longer in control of this panel.
  * Also, by storing the latest counter on which this panel updated
  *  the canvas we're able to detect when we lost the canvas,

--- a/package-res/lib/tipsy.js
+++ b/package-res/lib/tipsy.js
@@ -40,7 +40,7 @@
             $canvas,
             _isEnabledFun = opts.isEnabled,
             _sharedTipsyInfo;
-        
+
         function getTooltipText() {
             var instance = _mark.instance();
             var title =
@@ -317,7 +317,7 @@
             var fakeTipTarget = document.getElementById(_id);
             if(!fakeTipTarget) {
                 if(_tip.debug >= 20) _tip.log("[TIPSY] #" + _tipsyId + " Creating Fake Tip Target=" + _id);
-                
+
                 fakeTipTarget = document.createElement("div");
                 fakeTipTarget.id = _id;
                 fakeTipTarget.className = "fakeTipsyTarget";
@@ -337,7 +337,7 @@
             updateTipDebug();
 
             // Create the tipsy instance
-            $fakeTipTarget.data('tipsy', null); // Otherwise a new tipsy is not created, if there's one there already.
+            $fakeTipTarget.removeData('tipsy'); // Otherwise a new tipsy is not created, if there's one there already.
 
             var opts2 = Object.create(opts);
             // Gravity is intercepted to allow for off screen bounds reaction.
@@ -551,12 +551,12 @@
             if(_tip.debug >= 20) _tip.log("[TIPSY] #" + _tipsyId + " Hiding Immediately opId=" + opId);
             hideTipsyCore(opId);
         }
-    
+
         function disposeTipsy() {
             if(_tip.debug >= 20) _tip.log("[TIPSY] #" + _tipsyId + " Disposing");
             hideTipsyOther();
             if($fakeTipTarget) {
-                $fakeTipTarget.data("tipsy", null);
+                $fakeTipTarget.removeData("tipsy");
                 $fakeTipTarget.each(function(elem) { elem.$tooltipOptions = null; });
                 $fakeTipTarget.remove();
                 $fakeTipTarget = null;
@@ -566,13 +566,13 @@
                 $canvas = null;
             }
         }
-        
+
         function hideTipsyOther() {
             var opId = getNewOperationId();
             if(_tip.debug >= 20) _tip.log("[TIPSY] #" + _tipsyId + " Hiding as Other opId=" + opId);
             hideTipsyCore(opId);
         }
-    	
+
         function hideTipsyCore(opId) {
             // Uncomment to debug the tooltip markup.
             // Leaves the tooltip visible.
@@ -590,7 +590,7 @@
             if(hideTipsies && hideTipsies.length > 1) {
                 if(_tip.debug >= 20) _tip.group("[TIPSY] #" + _tipsyId + " Hiding Others");
                 hideTipsies.forEach(function(hideTipsyFun) {
-                    if(hideTipsyFun !== hideTipsyOther) hideTipsyFun();
+                    if(hideTipsyFun !== disposeTipsy) hideTipsyFun();
                 });
                 if(_tip.debug >= 20) _tip.groupEnd();
             }
@@ -808,6 +808,29 @@
         if(typeof console !== "undefined") console.groupEnd();
     };
 
+    _tip.disposeAll = function(panel) {
+        if(panel) {
+            var canvas = panel.root.canvas();
+            if(canvas) {
+                var $canvas = $(canvas),
+                    sharedTipsyInfo = $canvas.data("tipsy-pv-shared-info");
+                if(sharedTipsyInfo) {
+                    if(sharedTipsyInfo.behaviors)
+                        sharedTipsyInfo.behaviors.forEach(function(dispose) {
+                            dispose();
+                        });
+
+                    $canvas.removeData("tipsy-pv-shared-info");
+                }
+            }
+        }
+
+        _tip.removeAll();
+    };
+
+    _tip.removeAll = function() {
+        $('.tipsy').remove();
+    };
 
     function toParentTransform(parentPanel){
         return pv.Transform.identity.


### PR DESCRIPTION
…changing of chart type (5.4 Suite)

* Implemented a dispose method
  * Clears any tipsies (or leaks through jQuery handlers and attached data)
  * Disposes protovis root panel (events and main DOM references)
(cherry picked from commit 6866e82)

@dcleao, review it please. This is a backport of https://github.com/webdetails/ccc/pull/210 