### PR TITLE
[BACKLOG-9118] Removed extra prefix in legendOverflow name of the documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.iml
 /*.sublime-*
 .jshintrc
+package-pom.xml
 /viz/
 /doc/jsdoc/
 /doc/user-guide/

--- a/doc/model/panels/legend.xml
+++ b/doc/model/panels/legend.xml
@@ -105,7 +105,7 @@
             </c:documentation>
         </c:property>
 
-        <c:property name="legendOverflow" type="string pvc.options.varia.LegendOverflow" default="'clip'" category="Layout">
+        <c:property name="overflow" type="string pvc.options.varia.LegendOverflow" default="'clip'" category="Layout">
             <c:documentation>
                 The behavior of the legend panel when an overflow is detected.
 


### PR DESCRIPTION
@dcleao @nantunes @graimundo @carlosrusso @marcovala please review.