### PR TITLE
[BACKLOG-10583] Delay in showing axis label tooltips in charts

### DIFF
--- a/package-res/ccc/core/base/chart/chart.activeScene.js
+++ b/package-res/ccc/core/base/chart/chart.activeScene.js
@@ -57,18 +57,20 @@ pvc.BaseChart
      * @private
      */
     _activeSceneChange: function(ctx) {
-        var from = ctx.event.from, to = ctx.event.to;
+        this.useTextMeasureCache(function() {
+            var from = ctx.event.from, to = ctx.event.to;
 
-        // Change
-        if(from) from._clearActive();
-        if((this._activeScene = to)) to._setActive(true);
+            // Change
+            if(from) from._clearActive();
+            if((this._activeScene = to)) to._setActive(true);
 
-        // Render
-        // Unless from same panel (<=> same root scene).
-        if(from && (!to || to.root !== from.root))
-            from.panel().renderInteractive();
+            // Render
+            // Unless from same panel (<=> same root scene).
+            if(from && (!to || to.root !== from.root))
+                from.panel().renderInteractive();
 
-        if(to) to.panel().renderInteractive();
+            if(to) to.panel().renderInteractive();
+        });
     },
 
     /**


### PR DESCRIPTION
@nantunes @graimundo @marcovala @carlosrusso @dcleao please review.

Now using text measure cache in the 'renderInteractive' method when changing the active scene.

Also remove trimming algorithm that removed a letter at a time until the text
would feet inside the reserved space.

Using a ratio between the real word and the maximum size,
we were able to make better guesses for 'low', 'mid' and 'high' values
in the 'trimToWidthBin' algorithm. 