### PR TITLE
[BACKLOG-11154] A dimension with a converter could not use the Google…

### DIFF
--- a/doc/model/axes/axis-cartesian.xml
+++ b/doc/model/axes/axis-cartesian.xml
@@ -221,12 +221,17 @@
                 by automatically choosing an adequate precision,
                 that takes the actual data range into account.
                 It's also legacy, version 1, behavior.
+                Use the compatibility flag
+                <c:link to="pvc.options.varia.CompatibilityFlags#discreteTimeSeriesTickFormat" />
+                to disable this formatting mode.
 
                 Summing up:
                 <ul>
                     <li>a continuous axis uses the <i>continuous</i> arguments variant,</li>
                     <li>a discrete axis can use both arguments variant,</li>
-                    <li>an axis with a single date dimension, uses the <i>continuous</i> arguments variant.</li>
+                    <li>an axis with a single date dimension, uses the <i>continuous</i> arguments variant
+                        (if <c:link to="pvc.options.varia.CompatibilityFlags#discreteTimeSeriesTickFormat" /> is
+                        <tt>true</tt>).</li>
                 </ul>
 
                 <p><b>Context object</b></p>

--- a/doc/model/charts/basic.xml
+++ b/doc/model/charts/basic.xml
@@ -376,7 +376,8 @@
             </c:documentation>
         </c:property>
 
-        <c:property name="compatFlags" type="pvc.options.varia.CompatibilityFlags" category="Chart > General">
+        <c:property name="compatFlags" type="pvc.options.varia.CompatibilityFlags" category="Chart > General"
+                    excludeIn="cde">
             <c:documentation>
                 The set of compatibility flags.
 

--- a/doc/model/charts/basic.xml
+++ b/doc/model/charts/basic.xml
@@ -371,6 +371,16 @@
                 The CCC version that the chart should run in.
 
                 The value <tt>1</tt> emulates version 1 of CCC.
+
+                See also <c:link to="pvc.options.charts.BasicChart#compatFlags" />.
+            </c:documentation>
+        </c:property>
+
+        <c:property name="compatFlags" type="pvc.options.varia.CompatibilityFlags" category="Chart > General">
+            <c:documentation>
+                The set of compatibility flags.
+
+                See also <c:link to="pvc.options.charts.BasicChart#compatVersion" />.
             </c:documentation>
         </c:property>
 

--- a/doc/model/varia/_varia.xml
+++ b/doc/model/varia/_varia.xml
@@ -68,11 +68,12 @@
     <c:include the="varia/functions/dataWhere.xml" />
     <c:include the="varia/functions/slidingWindowFuns.xml" />
 
-    <!-- COMPLEX TYPES - AUXILIAR -->
+    <!-- COMPLEX TYPES - AUXILIARY -->
     <c:include the="varia/sides.xml" />
     <c:include the="varia/size.xml" />
     <c:include the="varia/tooltip.xml" />
     <c:include the="varia/visualRole.xml" />
     <c:include the="varia/pointing.xml" />
+    <c:include the="varia/compatFlags.xml" />
 
 </c:model>

--- a/doc/model/varia/atoms/legendOverflow.xml
+++ b/doc/model/varia/atoms/legendOverflow.xml
@@ -8,7 +8,7 @@
     <c:atomType name="LegendOverflow" space="pvc.options.varia" base="string">
         <c:documentation>
             Use these possible strategies when the number of legend items exceeds
-            the <c:link to="pvc.options.panels.ItemCountMax" /> or overflows the
+            the <c:link to="pvc.options.panels.LegendPanel#itemCountMax" /> or overflows the
             legend panel dimensions.
         </c:documentation>
 
@@ -25,7 +25,7 @@
                 the legend panel is hidden.
 
                 This option does not affect the case when the number
-                of legend items exceeds <c:link to="pvc.options.panels.ItemCountMax" />.
+                of legend items exceeds <c:link to="pvc.options.panels.LegendPanel#itemCountMax" />.
 
                 No overflow indicator is shown.
             </c:documentation>

--- a/doc/model/varia/compatFlags.xml
+++ b/doc/model/varia/compatFlags.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<c:model
+        xmlns:c="urn:webdetails/com/2012"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:webdetails/com/2012 ../../schema/com_2012.xsd"
+        xmlns="http://www.w3.org/1999/xhtml">
+
+    <c:complexType name="CompatibilityFlags" space="pvc.options.varia">
+        <c:documentation>
+            Compatibility flags control CCC features which are in the process of deprecation.
+
+            See also <c:link to="pvc.options.charts.BasicChart#compatVersion" /> and
+            <c:link to="pvc.options.charts.BasicChart#compatFlags" />.
+        </c:documentation>
+
+        <c:property name="discreteTimeSeriesTickFormat" type="boolean" default="true">
+            <c:documentation>
+                Enables discrete scale cartesian axes of single
+                <tt>Date</tt> dimension to format tick labels with a format that is determined
+                according to an automatically determined precision,
+                like it is done with cartesian axes of continuous scale.
+
+                This behaviour sometimes results in multiple categories being formatted with the
+                same label and is discouraged for use with generic data.
+
+                This option will have a default value of <tt>false</tt> when
+                <c:link to="pvc.options.charts.BasicChart#compatVersion" /> <tt>3</tt> is introduced and used.
+            </c:documentation>
+        </c:property>
+    </c:complexType>
+
+</c:model>

--- a/package-res/ccc/core/base/chart/chart.js
+++ b/package-res/ccc/core/base/chart/chart.js
@@ -192,6 +192,16 @@ def
     //------------------
     compatVersion: function(options) { return (options || this.options).compatVersion; },
 
+    /**
+     * Gets the value of a compatibility flag, given its name.
+     *
+     * @param {string} flagName - The name of the compatibility flag.
+     * @return {any} The value of the compatibility flag.
+     */
+    getCompatFlag: function(flagName) {
+        return this.options.compatFlags[flagName];
+    },
+
     _createLogId: function() {
         return "" + def.qualNameOf(this.constructor) + this._createLogChildSuffix();
     },
@@ -928,7 +938,10 @@ def
 
 //        renderCallback: undefined,
 
-        compatVersion: Infinity // numeric, 1 currently recognized
+        compatVersion: Infinity, // numeric, 1 currently recognized
+        compatFlags:   {
+            discreteTimeSeriesTickFormat: true
+        }
     }
 });
 

--- a/package-res/ccc/core/base/context.js
+++ b/package-res/ccc/core/base/context.js
@@ -43,7 +43,17 @@ def.type('pvc.visual.Context')
     },
     
     compatVersion: function() { return this.panel.compatVersion(); },
-    
+
+    /**
+     * Gets the value of a compatibility flag, given its name.
+     *
+     * @param {string} flagName - The name of the compatibility flag.
+     * @return {any} The value of the compatibility flag.
+     */
+    getCompatFlag: function(flagName) {
+        return this.panel.getCompatFlag(flagName);
+    },
+
     finished: function(v ) { return this.sign.finished(v ); },
     delegate: function(dv) { return this.sign.delegate(dv); },
     

--- a/package-res/ccc/core/base/panel/panel/panel.js
+++ b/package-res/ccc/core/base/panel/panel/panel.js
@@ -259,6 +259,16 @@ def
         return this.chart.compatVersion(options);
     },
 
+    /**
+     * Gets the value of a compatibility flag, given its name.
+     *
+     * @param {string} flagName - The name of the compatibility flag.
+     * @return {any} The value of the compatibility flag.
+     */
+    getCompatFlag: function(flagName) {
+        return this.chart.getCompatFlag(flagName);
+    },
+
     _createLogId: function() {
         return "" + def.qualNameOf(this.constructor) + this.chart._createLogChildSuffix();
     },

--- a/package-res/ccc/core/cartesian/axis/abstract-cart-axis-panel.js
+++ b/package-res/ccc/core/cartesian/axis/abstract-cart-axis-panel.js
@@ -508,7 +508,9 @@ def
             grouping = axis.role.grouping,
             tickFormatter = axis.option('TickFormatter');
 
-        if(grouping.isSingleDimension && grouping.lastDimensionValueType() === Date) {
+        if(this.getCompatFlag("discreteTimeSeriesTickFormat") &&
+           grouping.isSingleDimension &&
+           grouping.lastDimensionValueType() === Date) {
             // Calculate precision from values' extent.
             var domainValues = axis.domainValues(),
                 extent = def.query(domainValues).range();

--- a/package-res/cdo/dimension.js
+++ b/package-res/cdo/dimension.js
@@ -796,9 +796,11 @@ def.type('cdo.Dimension')
                 // Null after all
                 if(value == null || value === '') return this._nullAtom || dim_createNullAtom.call(this, sourceValue);
 
-                // Just in case it came from a google style cell.
-                // The value is now different from the original one, so the label is invalid.
-                label = undefined;
+                // Preserve the google style cell label.
+                // The converter is more like a parse function and should not be such that
+                // the corresponding label does not apply anymore - should return the same entity.
+                // If such an entity changing conversion is necessary, and google style cells
+                // are used, a reader should be used instead.
            }
         } else {
             value = sourceValue;
@@ -858,8 +860,12 @@ def.type('cdo.Dimension')
         var converter = type._converter;
         value = converter ? converter(sourceValue) : sourceValue;
         if(value == null || value === '') return null;
-        else if(!labelSpecified && converter) label = null;
-        
+        // Preserve the google style cell label.
+        // The converter is more like a parse function and should not be such that
+        // the corresponding label does not apply anymore - should return the same entity.
+        // If such an entity changing conversion is necessary, and google style cells
+        // are used, a reader should be used instead.
+
         // - CAST -
         // Any cast function?
         var cast = type.cast;


### PR DESCRIPTION
… Style Cell's `f` field, as it was reset. Now the label is preserved.

* Added the `compatFlags` option to support defining fine-tuned compatibility options;
future `compatVersion` values can map to sets of compat options' default values.
* Added the compatibility flag `discreteTimeSeriesTickFormat`.