### PR TITLE
[BACKLOG-9648] Optimize Chart#renderResize method to suppress rendering when minimum-size has been achieved.

### DIFF
--- a/doc/model/panels/title.xml
+++ b/doc/model/panels/title.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<c:model 
-    xmlns:c="urn:webdetails/com/2012" 
+<c:model
+    xmlns:c="urn:webdetails/com/2012"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="urn:webdetails/com/2012 ../../schema/com_2012.xsd"
     xmlns="http://www.w3.org/1999/xhtml">
-    
-    <c:complexType name="ChartTitlePanel" 
-                   space="pvc.options.panels" 
+
+    <c:complexType name="ChartTitlePanel"
+                   space="pvc.options.panels"
                    use="expanded"
                    base="pvc.options.panels.TitlePanel">
         <c:documentation>
             The options documentation class of the chart title panel.
         </c:documentation>
-        
-        <c:property name="position" 
+
+        <c:property name="position"
                     type="pvc.options.varia.PanelPosition"
                     category="Layout"
                     default="'top'">
@@ -21,77 +21,86 @@
                 The docking position of the panel.
             </c:documentation>
         </c:property>
-        
+
         <c:property name="font" type="string" default="'14px sans-serif'" category="Style">
             <c:documentation>
                 The font of the panel.
-                
-                See the supported font format in 
+
+                See the supported font format in
                 <c:link to="http://www.w3.org/TR/CSS2/fonts.html#font-shorthand" />
             </c:documentation>
         </c:property>
     </c:complexType>
-    
-    <c:complexType name="CartesianAxisTitlePanel" 
-                   space="pvc.options.panels" 
+
+    <c:complexType name="CartesianAxisTitlePanel"
+                   space="pvc.options.panels"
                    use="expanded"
                    base="pvc.options.panels.TitlePanel">
         <c:documentation>
             The options documentation class of the cartesian axes title panel.
         </c:documentation>
-        
-        <c:property name="position" 
+
+        <c:property name="position"
                     type="pvc.options.varia.PanelPosition"
                     fixed="null"
                     category="Layout">
             <c:documentation>
-                The position of the title panel is the same 
+                The position of the title panel is the same
                 as that of its cartesian axis.
             </c:documentation>
         </c:property>
-        
+
         <c:property name="paddings" type="string" fixed="null" category="Layout">
             <c:documentation>
                 The paddings of the panel. Not supported.
             </c:documentation>
         </c:property>
-        
+
         <c:property name="font" type="string" default="'12px sans-serif'" category="Style">
             <c:documentation>
                 The font of the panel.
-                
-                See the supported font format in 
+
+                See the supported font format in
                 <c:link to="http://www.w3.org/TR/CSS2/fonts.html#font-shorthand" />
             </c:documentation>
         </c:property>
     </c:complexType>
-    
-    <c:complexType name="TitlePanel" 
-                   space="pvc.options.panels" 
+
+    <c:complexType name="TitlePanel"
+                   space="pvc.options.panels"
                    base="pvc.options.panels.DockedPanel"
                    abstract="true">
         <c:documentation>
             The options documentation class of the title panel.
         </c:documentation>
-        
+
         <!--
         titleOffset // not documented
          -->
-         
-         <c:property name="extensionPoints" type="pvc.options.ext.TitlePanelExtensionPoints" category="Style" expandUse="optional">
+
+        <c:property name="visible" type="boolean" category="Layout">
+            <c:documentation>
+                Indicates if the title panel is visible.
+
+                The default value is <tt>true</tt>, if the <tt>title</tt> property is non-empty,
+                and <tt>false</tt>, otherwise.
+            </c:documentation>
+        </c:property>
+
+        <c:property name="extensionPoints" type="pvc.options.ext.TitlePanelExtensionPoints" category="Style" expandUse="optional">
             <c:documentation>
                 The extension points of the title panel.
             </c:documentation>
-         </c:property>
+        </c:property>
     </c:complexType>
-    
+
     <c:complexType name="TitlePanelExtensionPoints" space="pvc.options.ext" use="expanded">
         <c:documentation>
             The extension points of the title panel.
 
             Title extension points can also be specified directly at the chart options level.
 
-            To use an extension point you must find its full name. 
+            To use an extension point you must find its full name.
             If it is the chart's title panel, by joining:
             <ol>
                 <li>chart title panel property name: <tt>title</tt></li>
@@ -101,7 +110,7 @@
             </ol>
             and obtaining, for the examples, the camel-cased name: <tt>titleLabel_textStyle</tt>
             (see <c:link to="http://en.wikipedia.org/wiki/CamelCase" />).
-            
+
             If it is the title panel of an axis, by joining:
             <ol>
                 <li>chart axis panel property name (ex: <tt>xAxis</tt>)</li>
@@ -113,18 +122,18 @@
             and obtaining, for the examples, the camel-cased name: <tt>xAxisTitleLabel_textStyle</tt>
             (see <c:link to="http://en.wikipedia.org/wiki/CamelCase" />).
         </c:documentation>
-        
+
         <c:property name="_" type="pvc.options.marks.PanelExtensionPoint">
             <c:documentation>
                 The extension point of the top-level panel mark.
-                
-                This extension point, having no own name, 
+
+                This extension point, having no own name,
                 coincides with the property name of the panel.
-                For example, for the chart's title panel: 
+                For example, for the chart's title panel:
                 <tt>title_fillStyle</tt>.
             </c:documentation>
         </c:property>
-        
+
         <c:property name="label" type="pvc.options.marks.LabelExtensionPoint">
             <c:documentation>
                 The extension point of the title label mark.

--- a/package-res/ccc/core/base/chart/chart.js
+++ b/package-res/ccc/core/base/chart/chart.js
@@ -829,6 +829,7 @@ def
 
 //      smallContentMargins:  undefined,
 //      smallContentPaddings: undefined,
+//      smallTitleVisible:  undefined,
 //      smallTitlePosition: undefined,
 //      smallTitleAlign:    undefined,
 //      smallTitleAlignTo:  undefined,
@@ -869,7 +870,7 @@ def
         animate: true,
 
 //        title:         null,
-
+        //titleVisible:  undefined,
         titlePosition: "top", // options: bottom || left || right
         titleAlign:    "center", // left / right / center
 //        titleAlignTo:  undefined,

--- a/package-res/ccc/core/base/chart/chart.js
+++ b/package-res/ccc/core/base/chart/chart.js
@@ -730,6 +730,65 @@ def
         return this;
     },
 
+    /**
+     * Resizes a chart given new dimensions.
+     *
+     * When both dimensions are nully, this method does nothing.
+     *
+     * If the chart's previous layout, if any, had already reached its minimum size (in both directions),
+     * and the both the specified dimensions are smaller than or equal to the previous layout's
+     * requested size, then this method does nothing.
+     *
+     * This method does not perform render animations or reload data.
+     *
+     * @param {number} [width]  - The new width of the chart. Ignored when nully.
+     * @param {number} [height] - The new height of the chart. Ignored when nully.
+     *
+     * @returns {!pvc.visual.Chart} The chart instance.
+     */
+    renderResize: function(width, height) {
+
+        var canResizeWidth = width != null;
+        var canResizeHeight = height != null;
+
+        if(!canResizeWidth && !canResizeHeight) return this;
+
+        // Unfortunately, in the face of min-size constraints,
+        // the layout algorithm is sensitive to initial conditions.
+        // So the layout is prevented if the previous layout had already attempted to go below the minimum size.
+        var basePanel = this.basePanel;
+        if(basePanel) {
+            if(canResizeWidth) canResizeWidth = width !== basePanel.width;
+            if(canResizeHeight) canResizeHeight = height !== basePanel.height;
+
+            var prevLayoutInfo;
+            var sizeIncrease;
+            if((prevLayoutInfo = basePanel.getLayout()) && (sizeIncrease = prevLayoutInfo.sizeIncrease)) {
+
+                if(canResizeWidth) canResizeWidth = !sizeIncrease.width || (width > basePanel.width);
+                if(canResizeHeight) canResizeHeight = !sizeIncrease.height  || (height > basePanel.height);
+
+                if(!canResizeWidth && !canResizeHeight) return this;
+            }
+        }
+
+        // JIC the use changed options.width/height before calling this method,
+        // restoring the previous recreate values.
+
+        if(canResizeWidth)
+            this.options.width = width;
+        else if(basePanel)
+            this.options.width = this.width;
+
+
+        if(canResizeHeight)
+            this.options.height = height;
+        else if(basePanel)
+            this.options.height = this.height;
+
+        return this.render(true, true, false);
+    },
+
     _addErrorPanelMessage: function(text, isNoData) {
         var options = this.options,
             pvPanel = new pv.Panel()

--- a/package-res/ccc/core/base/chart/chart.panels.js
+++ b/package-res/ccc/core/base/chart/chart.panels.js
@@ -121,12 +121,15 @@ pvc.BaseChart
      */
     _initTitlePanel: function() {
         var o = this.options,
-            title = o.title;
+            title = o.title,
+            titleVisible = o.titleVisible;
 
-        if(!def.empty(title)) { // V1 depends on being able to pass "   " spaces...
+        // V1 depends on being able to pass "   " spaces...
+        if(titleVisible == null) titleVisible = !def.empty(title);
 
-            /* Save title layout information if this is a re-render and layout should be preserved 
-            This is done before replacing the old panel by a new one */
+        if(titleVisible) {
+            /* Save title layout information if this is a re-render and layout should be preserved
+               This is done before replacing the old panel by a new one */
             var titlePanel = this.titlePanel;
             var state;
             if(titlePanel && this._preserveLayout) state = titlePanel._getLayoutState();
@@ -157,7 +160,7 @@ pvc.BaseChart
         if(o.legend) { // legend is disabled on small charts...
             var legend = new pvc.visual.Legend(this, 'legend', 0);
 
-            /* Save legend layout information if this is a re-render and layout should be preserved 
+            /* Save legend layout information if this is a re-render and layout should be preserved
             This is done before replacing the old panel by a new one */
             var state;
 
@@ -342,7 +345,7 @@ pvc.BaseChart
         var panel = new PlotPanelClass(this, parentPanel, plot, options);
         var name = plot.name;
         var plotPanels = this.plotPanels;
-            
+
         plotPanels[plot.id] = panel;
         if(name) plotPanels[name] = panel;
         if(!plot.globalIndex) plotPanels.main = panel;

--- a/package-res/ccc/core/base/chart/chart.selection.js
+++ b/package-res/ccc/core/base/chart/chart.selection.js
@@ -52,19 +52,6 @@ pvc.BaseChart
     },
 
     /**
-     * Resizes and re-renders a chart given its new dimensions.
-     * @param {number} [width]  The new width of the chart. Ignored when undefined.
-     * @param {number} [height] The new height of the chart. Ignored when undefined.
-     * @returns {pvc.visual.Chart} The chart instance.
-     */
-    renderResize: function(width, height) {
-        if(width  !== undefined) this.options.width  = width;
-        if(height !== undefined) this.options.height = height;
-
-        return this.render(true, true, false);
-    },
-
-    /**
      * Processes any changed selections and, optionally,
      * re-renders the parts of the chart that show marks.
      *

--- a/package-res/ccc/core/base/multi/multiChart-panel.js
+++ b/package-res/ccc/core/base/multi/multiChart-panel.js
@@ -162,6 +162,7 @@ def
             Object.create(options),
                'parent',        chart,
                'legend',        false,
+               'titleVisible',  options.smallTitleVisible,
                'titleFont',     options.smallTitleFont,
                'titlePosition', options.smallTitlePosition,
                'titleAlign',    options.smallTitleAlign,

--- a/package-res/ccc/core/base/panel/title/abstract-title-panel.js
+++ b/package-res/ccc/core/base/panel/title/abstract-title-panel.js
@@ -67,8 +67,10 @@ def
             a_width = this.anchorLength(a),
             a_height = this.anchorOrthoLength(a),
 
+            title = this.title || "",
+
             // 2 - Small factor to avoid cropping text on either side
-            textWidth = pv.Text.measureWidth(this.title, this.font) + 2,
+            textWidth = pv.Text.measureWidth(title, this.font) + 2,
             clientWidthAvailable = layoutInfo.clientSize[a_width],
             clientWidthFix = layoutInfo.restrictions.clientSize[a_width];
 
@@ -77,8 +79,7 @@ def
         else if(clientWidthFix > clientWidthAvailable)
             clientWidthFix = clientWidthAvailable;
 
-        var title = this.title,
-            lines = !title ? [] :
+        var lines = !title ? [] :
                     (textWidth > clientWidthFix) ? pvc.text.justify(title, clientWidthFix, this.font) :
                     [title],
 

--- a/package-res/ccc/core/cartesian/axis/cart-axis.js
+++ b/package-res/ccc/core/cartesian/axis/cart-axis.js
@@ -956,6 +956,14 @@ pvc_CartesianAxis.options({
         cast:    String
     },
 
+    TitleVisible: {
+        resolve: '_resolveFull',
+        cast:  Boolean,
+        getDefault: function() {
+            return !def.empty(this.option("Title"));
+        }
+    },
+
     TitleSize: {
         resolve: '_resolveFull',
         cast:    cartAxis_castTitleSize

--- a/package-res/ccc/core/cartesian/cart-chart.js
+++ b/package-res/ccc/core/cartesian/cart-chart.js
@@ -212,12 +212,10 @@ def
 
         if(opts('Visible')) {
             var titlePanel;
-            var title = opts('Title');
-
             var panel = this.axesPanels[axis.id];
             var state;
 
-            if(!def.empty(title)) {
+            if(opts('TitleVisible')) {
                 // Save axes title panel's layout information if this is a re-render
                 // and layout should be preserved.
                 // This is done before replacing the old panel by a new one.
@@ -226,7 +224,7 @@ def
                 if(titlePanel && this._preserveLayout) state = titlePanel._getLayoutState();
 
                 titlePanel = new pvc.AxisTitlePanel(this, this.contentPanel, axis, {
-                    title:    title,
+                    title:    opts('Title'),
                     font:     opts('TitleFont') || opts('Font'),
                     anchor:   opts('Position'),
                     align:    opts('TitleAlign'),


### PR DESCRIPTION

@nantunes @graimundo @marcovala @carlosrusso @davidmsantos90 please review.

Unfortunately, this needs to be based on the previous, yet to be merged, PR, https://github.com/webdetails/ccc/pull/257.