### PR TITLE
[BACKLOG-11169] Fix comparer could not be null

### DIFF
--- a/package-res/cdo/meta/dimensionType.js
+++ b/package-res/cdo/meta/dimensionType.js
@@ -256,7 +256,7 @@ function(complexType, name, keyArgs) {
      */
     this._key = def.get(keyArgs, 'key') || null;
 
-    this.setComparer(def.get(keyArgs, 'comparer'));
+    this.setComparer(keyArgs && keyArgs.comparer);
 
     // TODO: inherit format from a specified prototype format instance.
 


### PR DESCRIPTION
Needed by https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/864.

@dcleao please review.