### PR TITLE
[BACKLOG-11724] Adding `pvc.CategoricalChartAbstract#_onWillCreatePlo…

### DIFF
--- a/doc/model/charts/common.xml
+++ b/doc/model/charts/common.xml
@@ -299,6 +299,11 @@
                     that is shown when the chart is provided with
                     no data or empty data.
                 </p>
+                <p>
+                    Set <tt>noDataMessage_visible</tt> to <tt>false</tt>
+                    to hide the error message and not render the chart in such a case.
+                    Rendering errors are made available through <tt>chart.getLastRenderError()</tt>.
+                </p>
             </c:documentation>
         </c:property>
 
@@ -315,6 +320,27 @@
                     Use <tt>invalidDataMessage_text</tt> to change the message
                     that is shown when a chart is provided with
                     invalid data.
+                </p>
+                <p>
+                    Set <tt>invalidDataMessage_visible</tt> to <tt>false</tt>
+                    to hide the error message and not render the chart in such a case.
+                    Rendering errors are made available through <tt>chart.getLastRenderError()</tt>.
+                </p>
+            </c:documentation>
+        </c:property>
+
+        <c:property name="errorMessage" type="pvc.options.marks.LabelExtensionPoint">
+            <c:documentation>
+                The extension point of a generic error label.
+                <p>
+                    Use <tt>errorMessage_text</tt> to change the message
+                    that is shown when the chart is provided with
+                    no data or empty data.
+                </p>
+                <p>
+                    Set <tt>errorMessage_visible</tt> to <tt>false</tt>
+                    to hide the error message and not render the chart in such a case.
+                    Rendering errors are made available through <tt>chart.getLastRenderError()</tt>.
                 </p>
             </c:documentation>
         </c:property>

--- a/package-res/ccc/core/base/chart/chart.data.js
+++ b/package-res/ccc/core/base/chart/chart.data.js
@@ -48,8 +48,7 @@ pvc.BaseChart
         // Child charts are created to consume *existing* data
         // If we don't have data, we just need to set a "no data" message and go on with life.
         if(!this.allowNoData && !this.resultset.length)
-            /*global NoDataException:true */
-            throw new NoDataException();
+            throw new pvc.NoDataException();
     },
 
     _checkNoDataII: function() {
@@ -59,8 +58,7 @@ pvc.BaseChart
 
             this.data = null;
 
-            /*global NoDataException:true */
-            throw new NoDataException();
+            throw new pvc.NoDataException();
         }
     },
 
@@ -80,7 +78,7 @@ pvc.BaseChart
                 // Existing data is kept.
                 // This is used for re-layouting only.
                 // Yet...
-                
+
                 // Dispose all data children and linked children (recreated as well)
                 // And clears caches as well.
                 data.disposeChildren();
@@ -97,8 +95,8 @@ pvc.BaseChart
             }
         } else {
             this.slidingWindow = this.parent.slidingWindow;
-            this._initAxes(); 
-        } 
+            this._initAxes();
+        }
 
         // Can only be done after axes creation
         if(this.slidingWindow) this.slidingWindow.setAxesDefaults(this);
@@ -168,7 +166,7 @@ pvc.BaseChart
         if(this.slidingWindow) {
             this.slidingWindow.setDimensionsOptions(complexType);
             this.slidingWindow.setLayoutPreservation(this);
-        } 
+        }
 
         data =
             this.dataEngine = // Legacy V1 property
@@ -177,13 +175,13 @@ pvc.BaseChart
                 labelSep: options.groupedLabelSep,
                 keySep:   options.dataOptions.separator
             });
-        
+
         this._initAxes();
 
         if(this.slidingWindow) {
             this.slidingWindow.initFromOptions();
             this.slidingWindow.setDataFilter(this.data);
-        } 
+        }
 
         // ----------
 
@@ -193,7 +191,7 @@ pvc.BaseChart
     _reloadData: function() {
         /*jshint expr:true*/
 
-        var data = this.data, 
+        var data = this.data,
             translation = this._translation;
 
         (data && translation) || def.assert("Invalid state.");
@@ -221,9 +219,9 @@ pvc.BaseChart
         if(def.debug >= 3) this.log(translation.logSource());
 
         var isMultiChartOverflowRetry = this._isMultiChartOverflowClipRetry;
-        
+
         this._initAxes();
-        this._loadDataCore(data, translation, {isAdditive : true});  
+        this._loadDataCore(data, translation, {isAdditive : true});
     },
 
     // ka - arguments

--- a/package-res/ccc/core/base/chart/chart.selection.js
+++ b/package-res/ccc/core/base/chart/chart.selection.js
@@ -45,8 +45,8 @@ pvc.BaseChart
      * @returns {pvc.visual.Chart} The chart instance.
      */
     renderInteractive: function() {
-        this.useTextMeasureCache(function() { 
-            this.basePanel.renderInteractive(); 
+        this.useTextMeasureCache(function() {
+            this.basePanel.renderInteractive();
         }, this);
         return this;
     },
@@ -104,7 +104,7 @@ pvc.BaseChart
         // Capture currently selected datums
         // Calculate the ones that changed.
 
-        // Caused by NoDataException ?
+        // Caused by pvc.NoDataException ?
         if(!this.data) return;
 
         var selectedChangedDatums,

--- a/package-res/ccc/core/base/panel/panel/panel.js
+++ b/package-res/ccc/core/base/panel/panel/panel.js
@@ -833,7 +833,7 @@ def
                     childKeyArgs.canChange = remTimes > 0;
 
                     child.layout(childKeyArgs);
-             
+
                     if(child.isVisible) {
                         resized = checkChildResize.call(this, child, canResize);
                         if(resized) return false; // stop
@@ -843,7 +843,7 @@ def
                         // Note that increased paddings will be provided by the parent panel,
                         // but at the cost of a decreased client size.
                         var contentOverflow = child._layoutInfo.contentOverflow;
-                  
+
                         if(checkContentOverflowChanged(paddings, contentOverflow)) {
                             paddings = contentOverflow;
 
@@ -1012,28 +1012,14 @@ def
      */
     _create: function(force) {
         if(!this.pvPanel || force) {
-            var invalidDataError;
-
-            delete this._invalidDataError;
-
             this.pvPanel = null;
             if(this.pvRootPanel) this.pvRootPanel = null;
 
             delete this._signs;
 
-            //region Root Layout
-            try {
-                this.layout();
-            } catch(ex) {
-                if(ex instanceof InvalidDataException)
-                    this._invalidDataError = invalidDataError = ex;
-                else
-                    throw ex;
-            }
-            //endregion
+            this.layout();
 
-            // Must repeat chart._create
-            // In principle, no invalidDataError will have been thrown
+            // Must repeat chart._create?
             if(this.isTopRoot && this.chart._isMultiChartOverflowClip) return;
 
             if(!this.isVisible) return;
@@ -1157,25 +1143,7 @@ def
 
             // Protovis marks that are pvc Panel specific,
             // and/or create child panels.
-            if(!invalidDataError) {
-                try {
-                    this._createCore(this._layoutInfo);
-                } catch(ex) {
-                    if(ex instanceof InvalidDataException)
-                        this._invalidDataError = invalidDataError = ex;
-                    else
-                        throw ex;
-                }
-            }
-
-            if(invalidDataError) {
-                var pvMsg = pvBorderPanel
-                    .anchor("center")
-                    .add(pv.Label)
-                    .text(invalidDataError.message);
-
-                this.chart.extend(pvMsg, "invalidDataMessage");
-            }
+            this._createCore(this._layoutInfo);
 
             if(this.isTopRoot) {
                 // Multi-chart overflow & clip
@@ -1260,11 +1228,6 @@ def
         if(!this.isVisible) return;
 
         var pvPanel = this.pvRootPanel;
-
-        if(this._invalidDataError) {
-            pvPanel.render();
-            return;
-        }
 
         this._onRender();
 

--- a/package-res/ccc/core/base/prologue.js
+++ b/package-res/ccc/core/base/prologue.js
@@ -32,14 +32,18 @@ pvc.invisibleFill = 'rgba(127,127,127,0.00001)';
  * @name NoDataException
  * @class An error thrown when a chart has no data.
  */
-def.global.NoDataException = function() {};
+pvc.NoDataException = def.global.NoDataException = function() {
+    this.name = "no-data";
+    this.message = "No data found";
+};
 
 /**
  * @name InvalidDataException
  * @class An error thrown when data exists but the chart cannot be rendered from it.
  */
-def.global.InvalidDataException = function(msg) {
-    this.message = msg ? msg : "Invalid Data.";
+pvc.InvalidDataException = def.global.InvalidDataException = function(msg, name) {
+    this.name = name || "invalid-data";
+    this.message = msg || "Invalid Data.";
 };
 
 /**

--- a/package-res/ccc/core/categorical/categ-chart.js
+++ b/package-res/ccc/core/categorical/categ-chart.js
@@ -6,4 +6,17 @@
  * CategoricalAbstract is the base class for all categorical or timeseries
  */
 def
-.type('pvc.CategoricalAbstract', pvc.CartesianAbstract);
+.type('pvc.CategoricalAbstract', pvc.CartesianAbstract)
+.add({
+    /**
+     * Called when the scene tree of a descendant categorical plot panel is to be created with the given data.
+     *
+     * @param {pvc.pvc.CategoricalAbstractPanel} plotPanel - The categorical plot panel.
+     * @param {pvc.data.Data} data - The visible data.
+     * @param {Array.<pvc.data.Data>} axisSeriesDatas - The visible axis series datas.
+     * @param {Array.<pvc.data.Data>} axisCategDatas - The visible axis categories datas.
+     * @abstract
+     */
+    _onWillCreatePlotPanelScene: function(plotPanel, data, axisSeriesDatas, axisCategDatas) {
+    }
+});

--- a/package-res/ccc/core/categorical/categ-plot-panel.js
+++ b/package-res/ccc/core/categorical/categ-plot-panel.js
@@ -5,8 +5,25 @@
 def
 .type('pvc.CategoricalAbstractPanel', pvc.CartesianAbstractPanel)
 .init(function(chart, parent, plot, options) {
-    
+
     this.base(chart, parent, plot, options);
-    
+
     this.stacked = plot.option('Stacked');
+})
+.add({
+    /**
+     * Builds the panel's scene tree based on the data to display.
+     *
+     * @param {pvc.data.Data} data - The visible data.
+     * @param {Array.<pvc.data.Data>} axisSeriesDatas - The visible axis series datas.
+     * @param {Array.<pvc.data.Data>} axisCategDatas - The visible axis categories datas.
+     * @return {pvc.visual.Scene} The root scene.
+     * @abstract
+     */
+    _buildScene: function(data, axisSeriesDatas, axisCategDatas) {
+
+        this.chart._onWillCreatePlotPanelScene(this, data, axisSeriesDatas, axisCategDatas);
+
+        return this._buildSceneCore(data, axisSeriesDatas, axisCategDatas);
+    }
 });

--- a/package-res/ccc/plugin/abstract-bar/abstract-bar-plot-panel.js
+++ b/package-res/ccc/plugin/abstract-bar/abstract-bar-plot-panel.js
@@ -546,7 +546,7 @@ def
         this.pvPanel.render();
     },
 
-    _buildScene: function(data, axisSeriesDatas, axisCategDatas) {
+    _buildSceneCore: function(data, axisSeriesDatas, axisCategDatas) {
         var rootScene  = new pvc.visual.Scene(null, {panel: this, source: data}),
             roles = this.visualRoles,
             valueVarHelper = new pvc.visual.RoleVarHelper(rootScene, 'value', roles.value, {hasPercentSubVar: this.stacked}),

--- a/package-res/ccc/plugin/box/box-plot-panel.js
+++ b/package-res/ccc/plugin/box/box-plot-panel.js
@@ -7,9 +7,9 @@
 def
 .type('pvc.BoxplotPanel', pvc.CategoricalAbstractPanel)
 .init(function(chart, parent, plot, options) {
-    
+
     this.base(chart, parent, plot, options);
-    
+
     this.boxSizeRatio = plot.option('BoxSizeRatio');
     this.boxSizeMax   = plot.option('BoxSizeMax');
 
@@ -25,7 +25,7 @@ def
         //'category': 'category',
         'value':    'median'
     },
-    
+
     /**
      * @override
      */
@@ -85,7 +85,7 @@ def
         function setupHCateg(sign) {
             sign.optionalMark(a_width, function() { return this.parent[a_width](); })
                 .optionalMark(a_left,  function() { return this.parent[a_width]()/2 - this[a_width]()/2; })
-            
+
             return sign;
         }
 
@@ -162,7 +162,7 @@ def
         function setupHRule(rule) {
             return setupRule(setupHCateg(rule));
         }
-        
+
         this.pvRuleMin = setupHRule(new pvc.visual.Rule(this, this.pvBoxPanel, {
                 extensionId:   'boxRuleMin',
                 freePosition:  true,
@@ -221,7 +221,7 @@ def
         this.pvBoxPanel.render();
     },
 
-    _buildScene: function(data, axisSeriesDatas, axisCategDatas) {
+    _buildSceneCore: function(data, axisSeriesDatas, axisCategDatas) {
         //  chart measureVisualRoles would only return bound visual roles.
         var measureVisualRoleInfos = def.query(this.visualRoleList)
                 .where(function(r) { return !r.isDiscrete() && r.isMeasure; })
@@ -322,7 +322,7 @@ def
                 if(group && (dimName = roleInfo.dimName)) {
                     var dim = group.dimensions(dimName),
                         value = dim.value(visibleKeyArgs);
-                    
+
                     svar = new pvc_ValueLabelVar(value, dim.format(value));
                     svar.position = orthoScale(value);
                 } else {
@@ -332,9 +332,9 @@ def
 
                 vars[roleInfo.roleName] = svar;
             });
-            
+
             colorVarHelper.onNewScene(categScene, /*isLeaf*/ true);
-            
+
             // ------------
 
             var hasMin    = vars.minimum.value  != null,
@@ -360,9 +360,9 @@ def
                     catVar.boxHeight = top - bottom;
                 }
             }
-            
+
             catVar.showBox  = show;
-            
+
             // vRules
             show = vars.maximum.value != null;
             if(show) {
@@ -371,7 +371,7 @@ def
                          hasLower  ? vars.lowerQuartil.position :
                          hasMin    ? vars.minimum.position  :
                          null;
-                
+
                 show = bottom != null;
                 if(show) {
                     catVar.ruleWhiskerUpperBottom = bottom;
@@ -397,9 +397,9 @@ def
                     catVar.ruleWhiskerLowerBottom = bottom;
                 }
             }
-            
+
             catVar.showRuleWhiskerBelow = show;
-            
+
             // hasMin = vars.minimum.value  != null,
         }
     }

--- a/package-res/ccc/plugin/heatGrid/hg-plot-panel.js
+++ b/package-res/ccc/plugin/heatGrid/hg-plot-panel.js
@@ -55,18 +55,23 @@ def
             a_width  = pvc.BasePanel.parallelLength[a_bottom],
             a_height = pvc.BasePanel.orthogonalLength[a_bottom],
 
-            // Column and Row datas
+            // Column (Categories) and Row (series) datas
             // One multi-dimension single-level data grouping
             // There's no series axis...so something like what an axis would select must be repeated here.
             // Maintaining order requires basing the operation on a data with nulls still in it.
             // `data` may not have nulls anymore.
-            rowRootData = me.visualRoles.series.flatten(
+            axisSeriesDatas = me.visualRoles.series.flatten(
                 me.partData(),
-                {visible: true, isNull: me.chart.options.ignoreNulls ? false : null}),
+                {visible: true, isNull: me.chart.options.ignoreNulls ? false : null}).childNodes,
+
+            data = me.visibleData({ignoreNulls: false}),
 
             // One multi-dimensional, two-levels grouping (Series -> Categ)
-            rootScene  = me._buildScene(me.visibleData({ignoreNulls: false}), rowRootData, cellSize),
-            hasColor   = rootScene.isColorBound,
+            rootScene  = me._buildScene(data, axisSeriesDatas, data.childNodes);
+
+        rootScene.cellSize = cellSize;
+
+        var hasColor   = rootScene.isColorBound,
             hasSize    = rootScene.isSizeBound,
             wrapper    = me._buildSignsWrapper(rootScene),
             isV1Compat = me.compatVersion() <= 1,
@@ -353,17 +358,14 @@ def
         this.pvPanel.render();
     },
 
-    _buildScene: function(data, seriesRootData, cellSize) {
+    _buildSceneCore: function(data, axisSeriesDatas, axisCategDatas) {
         var me = this,
             rootScene  = new pvc.visual.Scene(null, {panel: me, source: data}),
-            categDatas = data.childNodes,
             roles = me.visualRoles,
             colorVarHelper = new pvc.visual.RoleVarHelper(rootScene, 'color', roles.color),
             sizeVarHelper  = new pvc.visual.RoleVarHelper(rootScene, 'size',  roles.size);
 
-        rootScene.cellSize = cellSize;
-
-        seriesRootData.children().each(createSeriesScene);
+        axisSeriesDatas.forEach(createSeriesScene);
 
         return rootScene;
 
@@ -373,7 +375,7 @@ def
 
             serScene.vars.series = pvc_ValueLabelVar.fromComplex(serData1);
 
-            categDatas.forEach(function(catData1) {
+            axisCategDatas.forEach(function(catData1) {
                 createSeriesCategoryScene.call(me, serScene, catData1, serData1);
             });
         }

--- a/package-res/ccc/plugin/pie/pie-plot-panel.js
+++ b/package-res/ccc/plugin/pie/pie-plot-panel.js
@@ -299,7 +299,7 @@ def
 
                         if(!canHandle) return;
 
-                        var hide = false, 
+                        var hide = false,
                             m = pv.Text.measure(text, pvLabel.font()),
                             th = m.height * 0.85, // tight text bounding box
                             or = me.pvPie.outerRadius(),
@@ -316,7 +316,7 @@ def
                             // in the inner margin zone, which, after all, is supposed to not have any text!
                             twMax = (or - tm) - irmin;
 
-                        // If with this angle-span only at a very far 
+                        // If with this angle-span only at a very far
                         // radius would `thEf` be achieved, then text will never fit,
                         // not even trimmed.
                         hide |= (twMax <= 0);
@@ -325,7 +325,7 @@ def
                         twMax -= tm;
 
                         hide |= (this.hideOverflowed && m.width > twMax);
-                        
+
                         return {
                             hide: hide,
                             widthMax: twMax
@@ -537,7 +537,7 @@ def
         // Not possible to represent as pie if sumAbs = 0.
         // If this is a small chart, don't show message, which results in a pie with no slices..., a blank plot.
         if(!rootScene.childNodes.length && !panel.chart.visualRoles.multiChart.isBound())
-           throw new InvalidDataException("Unable to create a pie chart, please check the data values.");
+           throw new pvc.InvalidDataException("Unable to create a pie chart, please check the data values.", "all-zero-data");
     }
 
     function formatValue(value, categData) {

--- a/package-res/ccc/plugin/sunburst/sun-plot-panel.js
+++ b/package-res/ccc/plugin/sunburst/sun-plot-panel.js
@@ -13,7 +13,7 @@ def
     this.axes.size = chart._getAxis('size', (plot.option('SizeAxis') || 0) - 1); // may be undefined
 
     this.sliceOrder = plot.option('SliceOrder');
-    
+
     this.emptySlicesVisible = plot.option('EmptySlicesVisible');
 
     this.emptySlicesLabel = this.emptySlicesVisible ? plot.option('EmptySlicesLabel') : "";
@@ -34,7 +34,7 @@ def
         // Not possible to represent a sunburst if rootScene.vars.size.value = 0.
         // If this is a small chart, don't show message, which results in a blank plot.
         if(!rootScene.childNodes.length && !this.chart.visualRoles.multiChart.isBound())
-           throw new InvalidDataException("Unable to create a sunburst chart, please check the data values.");
+           throw new pvc.InvalidDataException("Unable to create a sunburst chart, please check the data values.", "all-zero-data");
 
         // Does not use sceneScale on purpose because of the 'nullToZero'
         // code not calling the base scale when null.
@@ -119,14 +119,14 @@ def
                             thEf = tb === 'middle'
                                 // quarter text margin on each side
                                 ? (th + tm/2)
-                                // one text margin, for the anchor, 
+                                // one text margin, for the anchor,
                                 // half text margin for the anchor's opposite side.
                                 // All on only one of the sides of the wedge.
                                 : 2 * (th + 3*tm/2);
 
                         // Minimum inner radius whose straight-arc has a length `thEf`
                         irmin = Math.max(
-                            irmin, 
+                            irmin,
                             thEf / (2 * Math.tan(a / 2)));
                     }
 
@@ -202,7 +202,7 @@ def
             // Ignore degenerate childs?
             if(!emptySlicesVisible)
                 children = children.where(function(childData) { return childData.value != null; });
-                
+
             if(!colorGrouping) {
                 scene.vars.color = new pvc_ValueLabelVar(null, "");
             } else {

--- a/package-res/ccc/plugin/treemap/treemap-plot-panel.js
+++ b/package-res/ccc/plugin/treemap/treemap-plot-panel.js
@@ -7,9 +7,9 @@
 def
 .type('pvc.TreemapPanel', pvc.PlotPanel)
 .init(function(chart, parent, plot, options) {
-    
+
     this.base(chart, parent, plot, options);
-    
+
     this.axes.size = chart._getAxis('size', (plot.option('SizeAxis') || 0) - 1); // may be undefined
 
     this.layoutMode = plot.option('LayoutMode');
@@ -28,7 +28,7 @@ def
         // Not possible to represent a treemap if rootScene.vars.size.value = 0.
         // If this is a small chart, don't show message, which results in a blank plot.
         if(!rootScene.childNodes.length && !this.chart.visualRoles.multiChart.isBound())
-           throw new InvalidDataException("Unable to create a treemap chart, please check the data values.");
+           throw new pvc.InvalidDataException("Unable to create a treemap chart, please check the data values.", "all-zero-data");
 
         var lw0 = def.number.to(me._getConstantExtension('leaf', 'lineWidth'), 1),
             lw  = lw0,
@@ -57,7 +57,7 @@ def
                 .lock('mode',    me.layoutMode)
                 .lock('order',   null) // TODO: option for this?
                 .lock('round',   false);
-        
+
         // Node prototype
         // Reserve space for interaction borders
         panel.node
@@ -65,9 +65,9 @@ def
             .top   (function(n) { return n.y  + lw2; })
             .width (function(n) { return n.dx - lw;  })
             .height(function(n) { return n.dy - lw;  });
-        
+
         // ------------------
-        
+
         var colorAxis = me.axes.color,
             colorScale = me.visualRoles.color.isBound()
                 ? colorAxis.sceneScale({sceneVarName: 'color'})
@@ -83,7 +83,7 @@ def
                 .strokeDasharray(function(scene) {
                     return scene.vars.size.value < 0 ? 'dash' : null; // Keep this in sync with the style in pvc.sign.DotSizeColor
                 });
-       
+
         new pvc.visual.Bar(me, panel.node, {
             extensionId: 'ascendant',
             noHover:  true,
@@ -93,9 +93,9 @@ def
             noTooltip: true
         })
         .intercept('visible', function(scene) {
-            return !!scene.parent && 
+            return !!scene.parent &&
                    !!scene.firstChild &&
-                   this.delegateExtension(true); 
+                   this.delegateExtension(true);
          })
         .override('anyInteraction', function(scene) {
             return scene.anyInteraction() || scene.isActiveDescendantOrSelf(); // special kind of interaction
@@ -122,7 +122,7 @@ def
         })
         .pvMark
         .antialias(false);
-        
+
         var label = pvc.visual.ValueLabel.maybeCreate(me, panel.label, {noAnchor: true});
         if(label) {
             label
@@ -148,14 +148,14 @@ def
                 var ta = pvLabel.textAngle(),
                     isHorizText = Math.abs(Math.sin(ta)) < 1e-6,
                     isVertiText = !isHorizText && Math.abs(Math.cos(ta)) < 1e-6;
-                
+
                 if(!isHorizText && !isVertiText) return;
 
                 var hide = false,
                     m  = pv.Text.measure(text, pvLabel.font()),
                     th = m.height * 0.75, // tight text bounding box
                     thMax = scene[isVertiText ? 'dx' : 'dy'];
-                
+
                 if(pvLabel.textBaseline() !== 'middle') thMax /= 2;
 
                 thMax -= 2*tm;
@@ -164,11 +164,11 @@ def
 
                 // Text Width
                 var twMax = scene[isVertiText ? 'dy' : 'dx'];
-                    
+
                 if(pvLabel.textAlign() !== 'center') twMax /= 2;
 
                 twMax -= 2*tm;
-                
+
                 hide |= ((twMax <= 0) || (this.hideOverflowed && m.width > twMax));
 
                 return {
@@ -179,11 +179,11 @@ def
             .override('getAnchoredToMark', function() { return pvLeafMark; });
         }
     },
-    
+
     renderInteractive: function() {
         this.pvTreemapPanel.render();
     },
-    
+
     // Returns null when all size-var values sum to 0.
     _buildScene: function() {
         // Hierarchical data, by categ1 (level1) , categ2 (level2), categ3 (level3),...
@@ -191,27 +191,27 @@ def
 
         // Everything hidden?
         if(!data.childCount()) return null;
-        
+
         var roles = this.visualRoles,
             rootScene     = new pvc.visual.Scene(null, {panel: this, source: data}),
             sizeVarHelper = new pvc.visual.RoleVarHelper(rootScene, 'size', roles.size, {allowNestedVars: true, hasPercentSubVar: true}),
             sizeIsBound   = roles.size.isBound(),
             colorGrouping = roles.color && roles.color.grouping,
             colorByParent = colorGrouping && this.plot.option('ColorMode') === 'byparent';
-        
+
         function recursive(scene) {
             var group = scene.group;
-            
+
             // The 'category' var value is the local group's value...
-            // 
+            //
             // When all categories are flattened into a single level
-            // of a data hierarchy, 
+            // of a data hierarchy,
             // each data's local key is compatible to the role key
             // (the one obtained by using:
             // cdo.Complex.compositeKey(complex, role.dimensionNames())
-            // That key will be the concatenation of the keys of all atoms 
+            // That key will be the concatenation of the keys of all atoms
             // (corresponding to the single level's dimensions).
-            // If any of these keys is empty, the key will contain 
+            // If any of these keys is empty, the key will contain
             // consecutive ~ separator characters, like "Foo~Bar~~Guru",
             // or even a trailing one: "Foo~Bar~Guru~".
             //
@@ -219,10 +219,10 @@ def
             // will contain all the keys of ascendant nodes, but no *trailing* empty keys.
             // The keys of compositeKeys are like if all keys were obtained
             // at the leaves of a regular tree (all branches have the same depth).
-            // When a leaf did not, in fact, exist, 
-            // an empty data node would be placed there anyway, 
+            // When a leaf did not, in fact, exist,
+            // an empty data node would be placed there anyway,
             // with an empty key.
-            // 
+            //
             // The two keys cannot currently be made compatible because
             // it seems that the waterfall's DfsPre/DfsPost flattening
             // needs the distinction between the key of the ancestor,
@@ -230,7 +230,7 @@ def
 
             // TODO: Should be the abs key (no trailing empty keys)
             scene.vars.category = pvc_ValueLabelVar.fromComplex(group);
-            
+
             // All nodes are considered leafs, for what the var helpers are concerned
             sizeVarHelper.onNewScene(scene, /*isLeaf*/ true);
             if(sizeIsBound && !scene.vars.size.value) {
@@ -246,7 +246,7 @@ def
                 .children()
                 .where(function(childData) { return childData.value != null; })
                 .array();
-                    
+
             if(!colorGrouping) {
                 if(!scene.parent) scene.vars.color = new pvc_ValueLabelVar(null, "");
             } else {
@@ -261,14 +261,14 @@ def
                     scene.vars.color = new pvc_ValueLabelVar(colorView.keyTrimmed(), colorView.label);
                 }
             }
-            
+
             children.forEach(function(childData) {
                 recursive(new pvc.visual.Scene(scene, {source: childData}));
             });
-            
+
             return scene;
         }
-        
+
         return recursive(rootScene);
     }
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -26,7 +26,7 @@ define([
         try {
             chart._create({});
         } catch(ex) {
-            if(!(ex instanceof def.global.NoDataException)) {
+            if(!(ex instanceof pvc.NoDataException)) {
                 throw ex;
             }
         }


### PR DESCRIPTION
…tPanelScene` to provide an easy way for external code to perform validation on the number of plot panel scenes.

* This is not a general mechanism. Does not handle multiple-plots well, as each plot is validated separately, instead of the sum of scenes of all plots being considered.
* This also does not handle multi-charts well.
* Defined a common `CategoricalPlotPanel#_buildScene` method to unify sub-classes.
* Added Chart#getLastRenderError() to allow knowing if a render was successful.
* Also, added a `name` property to CCC thrown errors, with the values:
  * "all-zero-data"
  * "invalid-data" (abstract; not being used)
  * "no-data"
* Render errors can also be any real Error object that is thrown during rendering, due to unforeseen reasons, in which case the value of their `name` property is defined by JavaScript.
* Don't render the chart when the top-level error panel is invisible.

Awaiting QA master validation.
@pamval please review.