### PR TITLE
[BACKLOG-15020] Fixes not taking into account the container element’s…

### DIFF
--- a/package-res/lib/protovis.js
+++ b/package-res/lib/protovis.js
@@ -11,7 +11,7 @@
  * the license for the specific language governing your rights and limitations.
  */
  /*! Copyright 2010 Stanford Visualization Group, Mike Bostock, BSD license. */
- /*! ec6ccdb829018e770984e19885835fdd0b600579 */
+ /*! 5558a26ae21bdde475aa1be0d4c4a90f35932d75 */
 /**
  * @class The built-in Array class.
  * @name Array
@@ -547,8 +547,8 @@ pv.elementOffset = function(elem) {
   var scrollTop  = win.pageYOffset || docElem.scrollTop;
   var scrollLeft = win.pageXOffset || docElem.scrollLeft;
   return {
-    top:  box.top  + scrollTop  - clientTop,
-    left: box.left + scrollLeft - clientLeft
+    top:  box.top  + scrollTop  - clientTop  - (elem.scrollTop  || 0),
+    left: box.left + scrollLeft - clientLeft - (elem.scrollLeft || 0)
   };
 };
 

--- a/package-res/lib/tipsy.js
+++ b/package-res/lib/tipsy.js
@@ -283,8 +283,8 @@
          */
         function setFakeTipTargetBounds(bounds) {
             $fakeTipTarget.css({
-                left:   bounds.left + parseFloat($canvas.css("padding-left")),
-                top:    bounds.top  + parseFloat($canvas.css("padding-top" )),
+                left:   bounds.left + parseFloat($canvas.css("padding-left")) + $canvas.scrollLeft(),
+                top:    bounds.top  + parseFloat($canvas.css("padding-top" )) + $canvas.scrollTop(),
                 width:  bounds.width,
                 height: bounds.height
             });
@@ -298,7 +298,14 @@
 
             $canvas = $(c);
 
-            c.style.position = "relative";
+            // Need a canvas that starts its own coordinate system
+            // so that the fakeTipTarget's position:absolute is relative to it and works.
+            // TODO: Ideally, we would be able to determine its position even if the
+            // nearest positioned ancestor is not the canvas.
+            var position = c.style.position;
+            if(!position || position === "static")
+                c.style.position = "relative";
+
             $canvas.mouseleave(hideTipsy);
 
             if(opts.usesPoint && opts.followMouse)


### PR DESCRIPTION
… scroll offset when converting mouse coordinates between screen and svg references.

@nantunes, @davidmsantos90, @carlosrusso please review.

Depends on and includes the binaries of: https://github.com/webdetails/protovis/pull/29.