### PR TITLE
[BACKLOG-15937] Fixed bug in CartesianAxis#_adjustDomain, in which th…

### DIFF
--- a/package-res/ccc/core/base/panel/dockingGrid-panel.js
+++ b/package-res/ccc/core/base/panel/dockingGrid-panel.js
@@ -295,7 +295,13 @@ def
                     // E.g. xAxisSize option is relative to the grid's client height.
                     sizeRef[p_aolen] = _layoutInfo.clientSize[p_aolen];
 
-                    _childLayoutKeyArgs.sizeAvailable = new pvc_Size(_fillSize);
+                    // Make things converge a bit faster by antecipating the assumption of the minimum `p_alen`.
+                    var sizeAvail = new pvc_Size(_fillSize);
+                    if(_fillSizeMin && sizeAvail[p_alen] < _fillSizeMin[p_alen]) {
+                        sizeAvail[p_alen] = _fillSizeMin[p_alen];
+                    }
+
+                    _childLayoutKeyArgs.sizeAvailable = sizeAvail;
                     _childLayoutKeyArgs.sizeRef = sizeRef;
                     //_childLayoutKeyArgs.paddings = null;//{}; // 0
                     _childLayoutKeyArgs.canChange = canChangeChild;
@@ -394,9 +400,8 @@ def
 
             // TODO: Can optimize these cases or not?
             // If has content overflow, need to relayout the side panels...
-            var i = (isFirstIteration && !_hasContentOverflow ? sideCount : 0) - 1;
-            i = -1;
-
+            //var i = (isFirstIteration && !_hasContentOverflow ? sideCount : 0) - 1;
+            var i = -1;
             var L = children.length;
 
             // First side child of an iteration resets the request paddings.

--- a/package-res/ccc/core/cartesian/axis/abstract-cart-axis-panel.js
+++ b/package-res/ccc/core/cartesian/axis/abstract-cart-axis-panel.js
@@ -582,16 +582,8 @@ def
         // in case _calcContinuousBandSizeMin does it for us.
         layoutInfo.ticks = layoutInfo.ticksText = null;
 
-        var anchorLength = this.anchorLength();
-        var clientLengthMin = 0;
-
-        var plotSizeMin = !this.chart.parent ? this.chart.options.plotSizeMin : null;
-        if(plotSizeMin != null && plotSizeMin[anchorLength] != null) {
-            clientLengthMin = plotSizeMin[anchorLength];
-        }
-
         var bandSizeMin  = this._calcContinuousBandSizeMin(),
-            clientLength = Math.max(layoutInfo.clientSize[anchorLength], clientLengthMin),
+            clientLength = layoutInfo.clientSize[this.anchorLength()],
             tickCountMax = this._calcContinuousTickCountMax(bandSizeMin, clientLength),
             ticks        = layoutInfo.ticks,
             roundOutside = this.axis.option('DomainRoundMode') === 'tick';

--- a/package-res/ccc/core/cartesian/axis/cart-axis.js
+++ b/package-res/ccc/core/cartesian/axis/cart-axis.js
@@ -182,7 +182,9 @@ def('pvc.visual.CartesianAxis', pvc_Axis.extend({
 
                 } else {
                     // Restore any initial domain, cause it may have been adjusted previously...
-                    this._adjustDomain(scale);
+                    // Force setting to the original domain, even if no adjustment seems to exist;
+                    // `scale.domain()` may now be different from `domainNice`.
+                    this._adjustDomain(scale, null, null, /*force: */true);
                 }
             }
         },
@@ -200,7 +202,8 @@ def('pvc.visual.CartesianAxis', pvc_Axis.extend({
          * Returns true if domain was aligned due to imposed ratio.
          */
         // ~ scale, domainNice, scale.size/range, Ratio, DomainAlign
-        _adjustDomain: function(scale, minIfLower, maxIfGreater) {
+        _adjustDomain: function(scale, minIfLower, maxIfGreater, force) {
+
             // This is the baseline domain for adjustments like tick rounding.
             var domainNice = this.domainNice;
             if(!domainNice) return false;
@@ -244,7 +247,7 @@ def('pvc.visual.CartesianAxis', pvc_Axis.extend({
                 }
             }
 
-            if(pv.floatEqual(dmin, dOrigMin) && pv.floatEqual(dmax, dOrigMax))
+            if(!force && pv.floatEqual(dmin, dOrigMin) && pv.floatEqual(dmax, dOrigMax))
                 return false;
 
             // Convert back values to their dimension's data types.

--- a/package-res/ccc/plugin/scatter/scatter-plot-panel.js
+++ b/package-res/ccc/plugin/scatter/scatter-plot-panel.js
@@ -203,7 +203,7 @@ def
             contentOverflow = {};
 
             /* The Worst case implementation would be like:
-             *   Use more padding than is required in many cases,
+             *   Uses more padding than is required in many cases,
              *   but ensures that no dot ever leaves the "stage".
              *
              *   Half a circle must fit in the client area
@@ -252,7 +252,7 @@ def
 
                     op[side] = (axisOffsetPaddings[side] || 0) *
                                (clientSize[len_a] + paddings[len_a]);
-                }, this);
+                });
             }
 
             var setSide = function(side, padding) {
@@ -269,10 +269,10 @@ def
                     r = Math.sqrt(sizeScale(hasSizeRole ? scene.vars.size.value : 0));
 
                 // How much overflow on each side?
-                setSide('left',   r - x);
-                setSide('bottom', r - y);
-                setSide('right',  x + r - xMax);
-                setSide('top',    y + r - yMax);
+                setSide('left',   r - x); // left   = x - r
+                setSide('bottom', r - y); // bottom = y - r
+                setSide('right',  x + r - xMax); // right = x + r (measured from left)
+                setSide('top',    y + r - yMax); // top = y + r  (measured from bottom)
             };
 
             rootScene


### PR DESCRIPTION
…e scale’s domain was not reset to its original domain.

This caused the tick-rounded domain of one layout iteration to affect the following iteration.
Moved the previous approach’s code by Nelson to its parent layout panel: DockingGridPanel.

See also related PR: https://github.com/webdetails/ccc/pull/292

@graimundo, @carlosrusso, @davidmsantos90, @nantunes please review.