### PR TITLE
[BACKLOG-16716] Changed the way in that the sunburst color scale repo…

### DIFF
--- a/package-res/ccc/plugin/sunburst/sun-plot-panel.js
+++ b/package-res/ccc/plugin/sunburst/sun-plot-panel.js
@@ -177,9 +177,11 @@ def
             colorMode = this.plot.option('ColorMode'),
             isColorModeFan = colorMode === 'fan',
             isColorModeLevel = colorMode === 'level',
-            colorScale =  roles.color.isBound()
+            isColorModeSlice = colorMode === 'slice',
+            colorScale = roles.color.isBound()
                 ? colorAxis.sceneScale({sceneVarName: 'color'})
                 : def.fun.constant(colorAxis.option('Unbound')),
+            colorAvailable = colorScale.available || def.retFalse,
             levels = 0,
             colorBrightnessFactor,
             sliceLevelAlphaRatio,
@@ -240,11 +242,15 @@ def
                 parent = scene.parent;
             if(parent) {
                 // level >= 1
-                // Returning a nully color means to derive the color from the parent.
-                // Hopefully, there's a parent that is not the root.
                 // First-level nodes should have an own color.
-                baseColor = colorScale(scene);
-                if(!baseColor && !parent.isRoot() && (baseColor = parent.color)) {
+                // Other levels get a color derived from its parent,
+                // unless a color is available for it.
+                var isColorAvailable = isColorModeSlice || parent.isRoot() || colorAvailable(scene.vars.color.value);
+
+                baseColor = isColorAvailable ? colorScale(scene) : null;
+
+                // Derive a color from the parent's color.
+                if(!baseColor && (baseColor = parent.color)) {
                     if(isColorModeFan) {
                         if(index && colorBrightnessFactor) {
                             baseColor = baseColor.brighter(colorBrightnessFactor * index / (siblingsSize - 1));


### PR DESCRIPTION
…rts that it has no fixed color for a value.

It used to be by returning `null`. However, the default protovis color scales return colors on a first-come-first-served basis, and, so, we’d never receive a `null` color back.
With these color scales there would be no way to ask if a color was available without automatically
assigning a color if not.
When fixing an error in the Common-UI sunburst viz, that was specifying a colormode of `slice` instead of `fan` it became clear that the CCC code was not working well for colorMode=fan and a color scale returning null. Fixing it for the Common-UI viz would break it for CCC with a default color scale…
So we had to change the “no color” protocol. Now, color scales may have an optional method, `available`,
which returns `true` if the given value has a color assigned to it, and `false` otherwise.
The Common-UI viz can then implement this method in its specially crafted color function,
and the default color scales won’t have the optional method.
Also fixed the order by which colors are assigned in colorMode=slice, now using breadth-first order (instead of depth-first). Still not perfect though as assigned colors should be sensitive to the SliceOrder option…

@webdetails/millenniumfalcon please review.

Merge with corresponding Common-UI PR.
