### PR TITLE
Revert "[ANALYZER-3616]-Chart Labels show incorrect formatting when different rows have "Matching Values""

### DIFF
--- a/package-res/cdo/dimension.js
+++ b/package-res/cdo/dimension.js
@@ -965,11 +965,11 @@ function dim_createAtom(type, sourceValue, key, value, label, isVirtual) {
         if(!label && def.debug >= 2) def.log("Only the null value should have an empty label.");
         
         // - ATOM! -
-        atom = new cdo.Atom(this, value, label, sourceValue, label);
+        atom = new cdo.Atom(this, value, label, sourceValue, key);
         if(isVirtual) atom.isVirtual = true;
     } else {
         var source = this.parent || this.linkParent;
-        atom = source._atomsByKey[label] ||
+        atom = source._atomsByKey[key] ||
                dim_createAtom.call(
                     source, 
                     type, 
@@ -985,7 +985,7 @@ function dim_createAtom(type, sourceValue, key, value, label, isVirtual) {
     
     dim_clearVisiblesCache.call(this);
     
-    this._atomsByKey[label] = atom;
+    this._atomsByKey[key] = atom;
     
     return atom;
 }


### PR DESCRIPTION
Reverts webdetails/ccc#297

This caused the viz's selections in analyzer to stop being marked.