### PR TITLE
[BACKLOG-19128] Fix to select on multiple lines legend to update all its items

### DIFF
--- a/package-res/ccc/core/base/panel/legend/legend-panel.js
+++ b/package-res/ccc/core/base/panel/legend/legend-panel.js
@@ -249,7 +249,7 @@ def
 
     // Catches both the marker and the label.
     // Also, if selection changes, renderInteractive re-renders these.
-    _getSelectableMarks: function() { return [this.pvLegendPanel]; },
+    _getSelectableMarks: function() { return [this.pvLegendPanel.parent]; },
 
     _getRootScene: function() {
         var rootScene = this._rootScene;


### PR DESCRIPTION
@webdetails/millenniumfalcon please review

By saying that the parent of a legend item is the selectable mark, it will update all sections inside the legend panel and not only the siblings of the selected section