### PR TITLE
[SP-4630] - Backport of CDE-975 - CCC BoxPlot Chart fails showing an …

### DIFF
--- a/ccc-js/src/main/javascript/package-res/ccc/plugin/box/box-plot-panel.js
+++ b/ccc-js/src/main/javascript/package-res/ccc/plugin/box/box-plot-panel.js
@@ -229,11 +229,11 @@ def
     _buildSceneCore: function(data, axisSeriesDatas, axisCategDatas) {
         //  chart measureVisualRoles would only return bound visual roles.
         var measureVisualRoleInfos = def.query(this.visualRoleList)
-                .where(function(r) { return r.isMeasureEffective; })
+                .where(function(r) { return !r.isDiscrete() && r.isMeasure; })
                 .select(function(r) {
                     return {
                         roleName: r.name,
-                        dimName:  r.grouping.singleDimensionName
+                        dimName:  r.grouping && r.grouping.singleDimensionName
                     };
                 })
                 .array(),


### PR DESCRIPTION
…empty dashboard with Cannot read property 'value' of undefined after upgrade