### PR TITLE
[BACKLOG-29056] Unable to drag all string and number fields into Weka…

### DIFF
--- a/ccc-js/src/main/javascript/package-res/ccc/core/base/multi/multiChart-panel.js
+++ b/ccc-js/src/main/javascript/package-res/ccc/core/base/multi/multiChart-panel.js
@@ -66,6 +66,7 @@ def
                 'smallColIndex', colIndex,
                 'smallRowIndex', rowIndex,
                 'title',         smallData.absLabel, // does not change with trends
+                'titleVisible',  true, // otherwise may not be created in case of empty smallData.absLabel...
                 'data',          smallData);
 
             var smallChart = new ChildClass(childOptions);


### PR DESCRIPTION
… visualization

- When the multi-chart role received a measure role with a null value, the small chart title panel would have an empty title and would not be created, later causing a NPE.

@webdetails/millenniumfalcon please review.