### PR TITLE
[SP-5253] - Backport of PPP-4406 - Special characters in Data are not…

### DIFF
--- a/ccc-js/src/main/javascript/package-res/ccc/core/cartesian/axis/abstract-cart-axis-panel.js
+++ b/ccc-js/src/main/javascript/package-res/ccc/core/cartesian/axis/abstract-cart-axis-panel.js
@@ -1131,7 +1131,7 @@ def
                     var pvMark = context.pvMark,
                         label  = context.scene.vars.tick.label;
 
-                    return pvMark.textAngle() || (pvMark.text() !== label) ? label : "";
+                    return pvMark.textAngle() || (pvMark.text() !== label) ? def.html.escape(label) : "";
                 };
             }
         }


### PR DESCRIPTION
… Escaped in Analyzer Labels, which could lead to Cross Site Scripting Attack (8.3 Suite)

@RPAraujo 
@smmribeiro 