### PR TITLE
[SP-6052] Backport of ANALYZER-2977 - Expose "axis" property in the JS context of axis tick formatter functions

### DIFF
--- a/ccc-js/src/main/javascript/package-res/ccc/core/base/axis/axis.js
+++ b/ccc-js/src/main/javascript/package-res/ccc/core/base/axis/axis.js
@@ -496,6 +496,8 @@ def('pvc.visual.Axis', pvc.visual.OptionsBase.extend({
 
             this._domainItems = domainItems;
             this._domainValues = domainValues;
+
+            domainValues.axis = this;
         },
         // endregion
 

--- a/ccc-js/src/main/javascript/package-res/ccc/core/cartesian/axis/abstract-cart-axis-panel.js
+++ b/ccc-js/src/main/javascript/package-res/ccc/core/cartesian/axis/abstract-cart-axis-panel.js
@@ -503,6 +503,8 @@ def
 
         layoutInfo.ticks = axis.domainItems();
 
+        var domainValues = axis.domainValues();
+
         // If the discrete data is of a single Date value type,
         // we want to format the category values with an appropriate precision,
         // instead of showing the default label.
@@ -515,7 +517,6 @@ def
            grouping.singleDimensionType.valueType === Date) {
 
             // Calculate precision from values' extent.
-            var domainValues = axis.domainValues();
             var extent = def.query(domainValues).range();
 
             // At least two atoms are required.
@@ -556,15 +557,8 @@ def
                 };
             }
         } else if(tickFormatter) {
-
-            var domainValueProp = axis.domainItemValueProp();
-
-            // TODO: In this case, unlike what is documented, `this` is not the ticks array...
-            format = function(child) {
-
-                var value = child[domainValueProp];
-
-                return tickFormatter(value, child.absLabel);
+            format = function(child, index) {
+                return tickFormatter.call(domainValues, domainValues[index], child.absLabel);
             };
         }
 

--- a/ccc-js/src/main/javascript/package-res/ccc/core/cartesian/axis/cart-axis.js
+++ b/ccc-js/src/main/javascript/package-res/ccc/core/cartesian/axis/cart-axis.js
@@ -421,7 +421,7 @@ def('pvc.visual.CartesianAxis', pvc_Axis.extend({
         },
 
         calcContinuousTicks: function(tickCountMax) {
-            return this.scale.ticks(this.desiredTickCount(), {
+            var ticks = this.scale.ticks(this.desiredTickCount(), {
                 roundInside:  this.option('DomainRoundMode') !== 'tick',
                 alignmentValue: this._state.tickAlignment,
                 tickCountMax: tickCountMax,
@@ -429,6 +429,10 @@ def('pvc.visual.CartesianAxis', pvc_Axis.extend({
                 precisionMin: this.tickUnitMinEf(),
                 precisionMax: this.tickUnitMaxEf()
             });
+
+            ticks.axis = this;
+
+            return ticks;
         },
 
         desiredTickCount: function() {

--- a/doc/model/axes/axis-cartesian.xml
+++ b/doc/model/axes/axis-cartesian.xml
@@ -250,6 +250,7 @@
                     <li>mult — the multiple of base precision that yields step (step = base * mult)</li>
                     <li>format(v) - the default formatting function</li>
                     <li>length — the number of ticks</li>
+                    <li>axis — the associated cartesian axis, <c:link to="pvc.options.axes.CartesianAxis" /></li>
                 </ul>
             </c:documentation>
         </c:property>


### PR DESCRIPTION
- This allows formatters to take the axis' formatting style (and any other configurations) into account.

Merge with: https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1549.